### PR TITLE
misc: adding cov regex to ignore files

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,6 @@
+exclude_paths:
+  - "**LICENSE**"
+  - "**.md"
+  - "**.toml"
+  - "**.yaml"
+  - "**.lock"

--- a/.github/scripts/run-cov.sh
+++ b/.github/scripts/run-cov.sh
@@ -10,7 +10,6 @@ CARGO_INCREMENTAL=0 RUSTFLAGS='-C instrument-coverage' LLVM_PROFILE_FILE='cargo-
 
 # Generate the coverage report using grcov
 # grcov . -s . --binary-path ./target/debug/ --branch --ignore-not-existing --ignore "/*" --ignore "target/debug/*" -o target/tarpaulin/coverage.xml
-cargo llvm-cov --all-features --workspace --cobertura --ignore-filename-regex ^(?!.*\.rs$|test_.*\.rs$|mod\.rs$|lib\.rs$|LICENSE$|Makefile$).*$|^(test_.*\.rs|mod\.rs|lib\.rs|LICENSE|Makefile)$
- --output-path target/coverage/coverage.xml
+cargo llvm-cov --all-features --workspace --cobertura --ignore-filename-regex '^(test_.*\.rs|mod\.rs|lib\.rs|LICENSE|Makefile)$|^[^\.]*$|^[^.]*\..[^r][^s]$|^[^.]*\.r[^s]$|^[^.]*\.[^r]s$' --output-path target/coverage/coverage.xml
 
 ls -la target/coverage

--- a/.github/scripts/run-cov.sh
+++ b/.github/scripts/run-cov.sh
@@ -10,6 +10,7 @@ CARGO_INCREMENTAL=0 RUSTFLAGS='-C instrument-coverage' LLVM_PROFILE_FILE='cargo-
 
 # Generate the coverage report using grcov
 # grcov . -s . --binary-path ./target/debug/ --branch --ignore-not-existing --ignore "/*" --ignore "target/debug/*" -o target/tarpaulin/coverage.xml
-cargo llvm-cov --all-features --workspace --cobertura --output-path target/coverage/coverage.xml
+cargo llvm-cov --all-features --workspace --cobertura --ignore-filename-regex ^(?!.*\.rs$|test_.*\.rs$|mod\.rs$|lib\.rs$|LICENSE$|Makefile$).*$|^(test_.*\.rs|mod\.rs|lib\.rs|LICENSE|Makefile)$
+ --output-path target/coverage/coverage.xml
 
 ls -la target/coverage


### PR DESCRIPTION
## Changes
* **Misc**
* * Adding regex to `cargo llvm-cov` to exclude coverage for some files
* * Adding `.codacy.yaml` file to exclude some files from static analysis

## References
- [Related issue](https://github.com/tamercuba/risp/issues)
