### PR TITLE
Refactor: Implementing a proper CST before de AST implementation

### DIFF
--- a/.cargo/docs-script.sh
+++ b/.cargo/docs-script.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cargo doc --open
 rustup doc --std --

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
-.vscode
+CLAUDE.md
+.claude/

--- a/risp/src/evaluator/implementation.rs
+++ b/risp/src/evaluator/implementation.rs
@@ -1,7 +1,7 @@
 use std::{ cell::RefCell, rc::Rc };
 use super::{ stdlib, SysCallWrapper };
 
-use crate::{ env::Env, lexer::Token, parser::Object };
+use crate::{ env::Env, lexer::{Lexer, Token}, parser::Object };
 
 pub struct Evaluator {
     env: Rc<RefCell<Env>>,
@@ -32,7 +32,7 @@ impl Evaluator {
     }
 
     pub fn eval(&mut self, statement: &str) -> Result<Object, String> {
-        let tokens = Token::tokenize(statement);
+        let tokens = Lexer::tokenize(statement);
         let parsed_list = Object::from_tokens(tokens);
         return match parsed_list {
             Ok(_) => self.eval_obj(&parsed_list.unwrap()),

--- a/risp/src/evaluator/implementation.rs
+++ b/risp/src/evaluator/implementation.rs
@@ -1,7 +1,7 @@
-use std::{ cell::RefCell, rc::Rc };
-use super::{ stdlib, SysCallWrapper };
+use super::{stdlib, SysCallWrapper};
+use std::{cell::RefCell, rc::Rc};
 
-use crate::{ env::Env, lexer::{Lexer, Token}, parser::Object };
+use crate::{env::Env, lexer::Lexer, parser::Object};
 
 pub struct Evaluator {
     env: Rc<RefCell<Env>>,
@@ -13,31 +13,37 @@ impl Evaluator {
         if with_stdlib {
             ev.add_stdlib();
         }
-        return ev;
+
+        ev
     }
 
     fn add_stdlib(&self) {
-        self.env
-            .borrow_mut()
-            .set("str", Object::SysCall(SysCallWrapper::new("str", stdlib::to_str)));
-        self.env
-            .borrow_mut()
-            .set("concat", Object::SysCall(SysCallWrapper::new("concatenate", stdlib::concat_str)));
-        self.env
-            .borrow_mut()
-            .set("first", Object::SysCall(SysCallWrapper::new("first", stdlib::list_take_first)));
-        self.env
-            .borrow_mut()
-            .set("println", Object::SysCall(SysCallWrapper::new("println", stdlib::print_ln)));
+        self.env.borrow_mut().set(
+            "str",
+            Object::SysCall(SysCallWrapper::new("str", stdlib::to_str)),
+        );
+        self.env.borrow_mut().set(
+            "concat",
+            Object::SysCall(SysCallWrapper::new("concatenate", stdlib::concat_str)),
+        );
+        self.env.borrow_mut().set(
+            "first",
+            Object::SysCall(SysCallWrapper::new("first", stdlib::list_take_first)),
+        );
+        self.env.borrow_mut().set(
+            "println",
+            Object::SysCall(SysCallWrapper::new("println", stdlib::print_ln)),
+        );
     }
 
     pub fn eval(&mut self, statement: &str) -> Result<Object, String> {
         let tokens = Lexer::tokenize(statement);
         let parsed_list = Object::from_tokens(tokens);
-        return match parsed_list {
+
+        match parsed_list {
             Ok(_) => self.eval_obj(&parsed_list.unwrap()),
             Err(_) => Err(format!("{}", parsed_list.err().unwrap())),
-        };
+        }
     }
 
     fn eval_obj(&mut self, obj: &Object) -> Result<Object, String> {
@@ -45,16 +51,10 @@ impl Evaluator {
             Object::List(list) => {
                 let result = self.eval_list(list);
                 match result {
-                    Ok(evalued_list) => {
-                        match evalued_list {
-                            Object::List(result_list) => {
-                                return self.eval_list(&result_list);
-                            }
-                            _ => {
-                                return Ok(evalued_list);
-                            }
-                        }
-                    }
+                    Ok(evalued_list) => match evalued_list {
+                        Object::List(result_list) => self.eval_list(&result_list),
+                        _ => Ok(evalued_list),
+                    },
                     Err(_) => result,
                 }
             }
@@ -65,13 +65,13 @@ impl Evaluator {
             Object::Bool(_) => Ok(obj.clone()),
             Object::Integer(n) => Ok(Object::Integer(*n)),
             Object::Symbol(s) => self.eval_symbol(s),
-            _ => { Err(format!("Invalid object: {:?}", obj)) }
+            _ => Err(format!("Invalid object: {:?}", obj)),
         }
     }
 
-    fn eval_function(&mut self, list: &Vec<Object>) -> Result<Object, String> {
+    fn eval_function(&mut self, list: &[Object]) -> Result<Object, String> {
         if list.len() != 4 {
-            return Err(format!("Invalid number of arguments for defun"));
+            return Err("Invalid number of arguments for defun".to_string());
         }
         match &list[1] {
             Object::Symbol(func_name) => {
@@ -82,51 +82,46 @@ impl Evaluator {
                             match param {
                                 Object::Symbol(s) => params.push(s.clone()),
                                 _ => {
-                                    return Err(format!("Invalid defun parameter"));
+                                    return Err("Invalid defun parameter".to_string());
                                 }
                             }
                         }
                         params
                     }
                     _ => {
-                        return Err(format!("Invalid defun"));
+                        return Err("Invalid defun".to_string());
                     }
                 };
 
                 let body = match &list[3] {
                     Object::List(list) => list.clone(),
                     _ => {
-                        return Err(format!("Invalid defun"));
+                        return Err("Invalid defun".to_string());
                     }
                 };
                 let f = Object::Function(params, body);
                 self.env.borrow_mut().set(func_name.as_str(), f);
                 Ok(Object::Void)
             }
-            _ => {
-                return Err(format!("Invalid defun"));
-            }
+            _ => Err("Invalid defun".to_string()),
         }
     }
 
     fn eval_list(&mut self, list: &Vec<Object>) -> Result<Object, String> {
         let head = &list[0];
         match head {
-            Object::Symbol(s) =>
-                match s.as_str() {
-                    // TODO: Add more binary operators
-                    "+" | "-" | "*" | "/" | "<" | ">" | "=" | "!=" => {
-                        return self.eval_binary_op(&list);
-                    }
-                    "let" => self.eval_let(&list),
-                    "defun" => self.eval_function(&list),
-                    "if" => self.eval_if(&list),
-                    "lambda" => self.eval_lambda(&list),
-                    "true" | "false" => Ok(Object::Bool(s == "true")),
-                    // TODO: Add a basic std lib
-                    _ => self.eval_func_call(&s, &list),
-                }
-            Object::Lambda(params, body) => self.eval_anon_func_call(params, body, &list),
+            Object::Symbol(s) => match s.as_str() {
+                // TODO: Add more binary operators
+                "+" | "-" | "*" | "/" | "<" | ">" | "=" | "!=" => self.eval_binary_op(list),
+                "let" => self.eval_let(list),
+                "defun" => self.eval_function(list),
+                "if" => self.eval_if(list),
+                "lambda" => self.eval_lambda(list),
+                "true" | "false" => Ok(Object::Bool(s == "true")),
+                // TODO: Add a basic std lib
+                _ => self.eval_func_call(s, list),
+            },
+            Object::Lambda(params, body) => self.eval_anon_func_call(params, body, list),
             _ => {
                 let mut new_list = Vec::new();
                 for obj in list {
@@ -158,9 +153,9 @@ impl Evaluator {
         }
     }
 
-    fn eval_binary_op(&mut self, list: &Vec<Object>) -> Result<Object, String> {
+    fn eval_binary_op(&mut self, list: &[Object]) -> Result<Object, String> {
         if list.len() != 3 {
-            return Err(format!("Invalid number of arguments for binary operation"));
+            return Err("Invalid number of arguments for binary operation".to_string());
         }
 
         let operator = list[0].clone();
@@ -180,32 +175,30 @@ impl Evaluator {
         };
 
         match operator {
-            Object::Symbol(s) =>
-                match s.as_str() {
-                    "+" => Ok(Object::Integer(left_val + right_val)),
-                    "-" => Ok(Object::Integer(left_val - right_val)),
-                    "*" => Ok(Object::Integer(left_val * right_val)),
-                    "/" => {
-                        match right_val {
-                            0 => {
-                                return Err(format!("Division by zero"));
-                            }
-                            _ => Ok(Object::Integer(left_val / right_val)),
-                        }
-                    }
-                    "<" => Ok(Object::Bool(left_val < right_val)),
-                    ">" => Ok(Object::Bool(left_val > right_val)),
-                    "=" => Ok(Object::Bool(left_val == right_val)),
-                    "!=" => Ok(Object::Bool(left_val != right_val)),
-                    _ => Err(format!("Invalid infix operator: {}", s)),
-                }
-            _ => Err(format!("Operator must be a symbol")),
+            Object::Symbol(s) => match s.as_str() {
+                "+" => Ok(Object::Integer(left_val + right_val)),
+                "-" => Ok(Object::Integer(left_val - right_val)),
+                "*" => Ok(Object::Integer(left_val * right_val)),
+                "/" => match right_val {
+                    0 => Err("Division by zero".to_string()),
+                    _ => Ok(Object::Integer(left_val / right_val)),
+                },
+                "<" => Ok(Object::Bool(left_val < right_val)),
+                ">" => Ok(Object::Bool(left_val > right_val)),
+                "=" => Ok(Object::Bool(left_val == right_val)),
+                "!=" => Ok(Object::Bool(left_val != right_val)),
+                _ => Err(format!("Invalid infix operator: {}", s)),
+            },
+            _ => Err("Operator must be a symbol".to_string()),
         }
     }
 
-    fn eval_let(&mut self, list: &Vec<Object>) -> Result<Object, String> {
+    fn eval_let(&mut self, list: &[Object]) -> Result<Object, String> {
         if list.len() < 2 {
-            return Err(format!("Expect at least one argument for let, got {}", list.len() - 1));
+            return Err(format!(
+                "Expect at least one argument for let, got {}",
+                list.len() - 1
+            ));
         }
 
         let mut result: Result<Object, String> = Ok(Object::Void);
@@ -214,23 +207,22 @@ impl Evaluator {
                 // Let is a local definition keyword
                 // So if we have a single symbol and a single value
                 // like (let x 10), there is nothing to do unless return Void
-                return Ok(Object::Void);
+                Ok(Object::Void)
             }
-            (Object::Symbol(s), None) => {
-                return Err(format!("Invalid syntax, there is no value to assign to {}", s));
-            }
+            (Object::Symbol(s), None) => Err(format!(
+                "Invalid syntax, there is no value to assign to {}",
+                s
+            )),
             (Object::List(l), &body) => {
                 self.env = Env::new_scope(self.env.clone());
                 for obj in l {
                     match obj {
                         Object::List(arg) => {
                             if arg.len() != 2 {
-                                return Err(
-                                    format!(
-                                        "Invalid syntax, expected a list of 2 elements, got {}",
-                                        arg.len()
-                                    )
-                                );
+                                return Err(format!(
+                                    "Invalid syntax, expected a list of 2 elements, got {}",
+                                    arg.len()
+                                ));
                             }
                             match &arg[0] {
                                 Object::Symbol(s) => {
@@ -238,9 +230,10 @@ impl Evaluator {
                                     self.env.borrow_mut().set(s.clone().as_str(), val);
                                 }
                                 _ => {
-                                    return Err(
-                                        format!("{} is a invalid symbol to let assignment", arg[0])
-                                    );
+                                    return Err(format!(
+                                        "{} is a invalid symbol to let assignment",
+                                        arg[0]
+                                    ));
                                 }
                             }
                         }
@@ -248,46 +241,39 @@ impl Evaluator {
                             return Err(format!("Invalid syntax, expected a list, got {}", obj));
                         }
                     }
-                    match body {
-                        Some(b) => {
-                            result = self.eval_obj(b);
-                        }
-                        None => {}
+                    if let Some(b) = body {
+                        result = self.eval_obj(b);
                     }
                 }
                 self.env.borrow_mut().remove_scope();
-                return result;
+                result
             }
-            _ => {
-                return Err(
-                    format!(
-                        "Invalid assignment syntax for {} with value {}",
-                        list[1],
-                        list.get(2).unwrap_or(&Object::Void)
-                    )
-                );
-            }
+            _ => Err(format!(
+                "Invalid assignment syntax for {} with value {}",
+                list[1],
+                list.get(2).unwrap_or(&Object::Void)
+            )),
         }
     }
 
-    fn eval_if(&mut self, list: &Vec<Object>) -> Result<Object, String> {
+    fn eval_if(&mut self, list: &[Object]) -> Result<Object, String> {
         if list.len() != 4 {
-            return Err(format!("Invalid number of arguments for if"));
+            return Err("Invalid number of arguments for if".to_string());
         }
 
         let cond_obj = self.eval_obj(&list[1])?;
         let cond = match cond_obj {
             Object::Bool(b) => b,
             _ => {
-                return Err(format!("Invalid condition"));
+                return Err("Invalid condition".to_string());
             }
         };
 
-        let return_idx = if cond == true { 2 } else { 3 };
-        return self.eval_obj(&list[return_idx]);
+        let return_idx = if cond { 2 } else { 3 };
+        self.eval_obj(&list[return_idx])
     }
 
-    fn eval_lambda(&mut self, list: &Vec<Object>) -> Result<Object, String> {
+    fn eval_lambda(&mut self, list: &[Object]) -> Result<Object, String> {
         let params = match &list[1] {
             Object::List(list) => {
                 let mut params = Vec::new();
@@ -295,28 +281,28 @@ impl Evaluator {
                     match param {
                         Object::Symbol(s) => params.push(s.clone()),
                         _ => {
-                            return Err(format!("Invalid lambda parameter"));
+                            return Err("Invalid lambda parameter".to_string());
                         }
                     }
                 }
                 params
             }
             _ => {
-                return Err(format!("Invalid lambda"));
+                return Err("Invalid lambda".to_string());
             }
         };
 
         let body = match &list[2] {
             Object::List(list) => list.clone(),
             _ => {
-                return Err(format!("Invalid lambda"));
+                return Err("Invalid lambda".to_string());
             }
         };
         let result = Object::Lambda(params, body);
         Ok(result)
     }
 
-    fn eval_func_call(&mut self, func_name: &str, list: &Vec<Object>) -> Result<Object, String> {
+    fn eval_func_call(&mut self, func_name: &str, list: &[Object]) -> Result<Object, String> {
         let func_result = self.env.borrow_mut().get(func_name);
         if func_result.is_none() {
             return Err(format!("Function not defined: {}", func_name));
@@ -332,7 +318,7 @@ impl Evaluator {
                 }
                 let result = self.eval_obj(&Object::List(body));
                 self.env.borrow_mut().remove_scope();
-                return result;
+                result
             }
             Object::SysCall(sys_call) => {
                 let mut args = Vec::new();
@@ -340,22 +326,20 @@ impl Evaluator {
                     let val = self.eval_obj(arg)?;
                     args.push(val.clone());
                 }
-                return sys_call.run(&args);
+                sys_call.run(&args)
             }
-            _ => {
-                return Err(format!("Not a function: {}", func_name));
-            }
+            _ => Err(format!("Not a function: {}", func_name)),
         }
     }
 
     fn eval_anon_func_call(
         &mut self,
-        params: &Vec<String>,
-        body: &Vec<Object>,
-        list: &Vec<Object>
+        params: &[String],
+        body: &[Object],
+        list: &[Object],
     ) -> Result<Object, String> {
         if params.len() != list.len() - 1 {
-            return Err(format!("Invalid number of arguments for lambda"));
+            return Err("Invalid number of arguments for lambda".to_string());
         }
 
         self.env = Env::new_scope(self.env.clone());
@@ -363,8 +347,8 @@ impl Evaluator {
             let val = self.eval_obj(&list[i + 1])?;
             self.env.borrow_mut().set(param, val);
         }
-        let result = self.eval_obj(&Object::List(body.clone()));
+        let result = self.eval_obj(&Object::List(body.to_vec()));
         self.env.borrow_mut().remove_scope();
-        return result;
+        result
     }
 }

--- a/risp/src/evaluator/mod.rs
+++ b/risp/src/evaluator/mod.rs
@@ -1,6 +1,6 @@
 mod implementation;
-mod test_evaluator;
 mod stdlib;
+mod test_evaluator;
 
 pub use crate::evaluator::implementation::Evaluator;
 pub use crate::evaluator::stdlib::SysCallWrapper;

--- a/risp/src/lexer/implementation.rs
+++ b/risp/src/lexer/implementation.rs
@@ -1,181 +1,85 @@
-use std::fmt::{ Display, Debug };
+use super::token::{Content, Span, Token};
 
-#[derive(Clone)]
-pub struct Content<T> {
-    pub content: T,
-    pub ch: usize,
-    pub line: usize,
+pub struct Lexer {
+    tokens: Vec<Token>,
+    buffer: String,
+    buffer_lo: u32,
+    in_comment: bool,
 }
 
-impl<T> Display for Content<T> where T: Debug {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{line}:{ch} {content}",
-            line = self.line,
-            ch = self.ch.clone(),
-            content = format!("{:?}", self.content)
-        )
-    }
-}
-
-impl<T> Debug for Content<T> where T: Debug {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{line}:{ch} {content}",
-            line = self.line,
-            ch = self.ch.clone(),
-            content = format!("{:?}", self.content)
-        )
-    }
-}
-
-impl<T> PartialEq for Content<T> where T: PartialEq {
-    fn eq(&self, other: &Self) -> bool {
-        self.content == other.content
-    }
-}
-
-impl<T> Eq for Content<T> where T: Eq {}
-
-impl<T> Content<T> {
-    pub fn new(content: T, ch: usize, line: usize) -> Self {
-        Content {
-            content,
-            ch,
-            line,
+impl Default for Lexer {
+    fn default() -> Self {
+        Self {
+            tokens: vec![],
+            buffer: String::new(),
+            buffer_lo: 0,
+            in_comment: false,
         }
     }
 }
 
-#[derive(PartialEq, Clone)]
-pub enum Token {
-    Integer(Content<i64>),
-    Symbol(Content<String>),
-    LParen(Content<()>),
-    RParen(Content<()>),
-}
-
-impl Display for Token {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Token::Integer(c) =>
-                write!(f, "{line}:{ch} Int({value})", line = c.line, ch = c.ch, value = c.content),
-            Token::Symbol(c) =>
-                write!(
-                    f,
-                    "{line}:{ch} Symbol({value})",
-                    line = c.line,
-                    ch = c.ch,
-                    value = c.content
-                ),
-            Token::LParen(c) => write!(f, "{line}:{ch} LParen", line = c.line, ch = c.ch),
-            Token::RParen(c) => write!(f, "{line}:{ch} RParen", line = c.line, ch = c.ch),
-        }
-    }
-}
-
-impl Debug for Token {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Token::Integer(c) =>
-                write!(f, "{line}:{ch} Int({value})", line = c.line, ch = c.ch, value = c.content),
-            Token::Symbol(c) =>
-                write!(
-                    f,
-                    "{line}:{ch} Symbol({value})",
-                    line = c.line,
-                    ch = c.ch,
-                    value = c.content
-                ),
-            Token::LParen(c) => write!(f, "{line}:{ch} LParen", line = c.line, ch = c.ch),
-            Token::RParen(c) => write!(f, "{line}:{ch} RParen", line = c.line, ch = c.ch),
-        }
-    }
-}
-
-impl Token {
+impl Lexer {
     pub fn tokenize(program: &str) -> Vec<Token> {
-        let mut tokens: Vec<Token> = vec![];
+        let mut lexer = Lexer::default();
 
-        let mut line: usize = 0;
+        for (ch_offset, ch) in program.char_indices() {
+            if lexer.in_comment {
+                if ch == '\n' || ch == '\r' {
+                    lexer.in_comment = false;
+                }
+                continue;
+            }
 
-        let lines = program.lines();
-        for file_line in lines {
-            let mut new_tokens = Self::parse_line(&file_line, line);
-            tokens.append(&mut new_tokens);
-            line += 1;
-        }
-
-        return tokens;
-    }
-
-    fn parse_line(program: &str, line: usize) -> Vec<Token> {
-        let mut tokens: Vec<Token> = vec![];
-        let mut ch: usize = 0;
-        let mut chars = program.chars().peekable();
-        let mut current_buffer = String::new();
-
-        while let Some(&current) = chars.peek() {
-            match current {
+            match ch {
                 '(' => {
-                    if !current_buffer.is_empty() {
-                        Self::parse_buffer(&current_buffer.clone(), &mut tokens, &mut ch, line);
-                        current_buffer.clear();
-                    }
-                    ch += 1;
-                    tokens.push(Token::LParen(Content::new((), ch.clone(), line.clone())));
-                    chars.next();
+                    lexer.flush_buffer(ch_offset);
+                    lexer.push_token(Token::LParen(Content::new((), Span::at(ch_offset))));
                 }
                 ')' => {
-                    if !current_buffer.is_empty() {
-                        Self::parse_buffer(&current_buffer.clone(), &mut tokens, &mut ch, line);
-                        current_buffer.clear();
-                    }
-                    ch += 1;
-                    tokens.push(Token::RParen(Content::new((), ch.clone(), line.clone())));
-                    chars.next();
+                    lexer.flush_buffer(ch_offset);
+                    lexer.push_token(Token::RParen(Content::new((), Span::at(ch_offset))));
                 }
-                ' ' => {
-                    if !current_buffer.is_empty() {
-                        let value = current_buffer.clone();
-                        Self::parse_buffer(&value, &mut tokens, &mut ch, line);
-                        current_buffer.clear();
-                    }
-                    ch += 1;
-                    chars.next();
+                ' ' | '\t' | '\n' | '\r' => {
+                    lexer.flush_buffer(ch_offset);
+                }
+                ';' => {
+                    lexer.flush_buffer(ch_offset);
+                    lexer.in_comment = true;
                 }
                 _ => {
-                    current_buffer.push(current);
-                    ch += 1;
-                    chars.next();
+                    lexer.push_to_buffer(ch, ch_offset);
                 }
             }
         }
-        if !current_buffer.is_empty() {
-            let value = current_buffer.clone();
-            Self::parse_buffer(&value, &mut tokens, &mut ch, line);
-        }
-        tokens
+
+        lexer.flush_buffer(program.len());
+        lexer.tokens
     }
 
-    fn parse_buffer(buffer: &str, tokens: &mut Vec<Token>, ch: &mut usize, line: usize) {
-        let buffer_size = buffer.len();
-        let current_pos = ch.clone() - buffer_size + 1;
-        match buffer.is_empty() {
-            true => (),
-            false =>
-                match buffer.parse::<i64>() {
-                    Ok(value) =>
-                        tokens.push(Token::Integer(Content::new(value, current_pos, line.clone()))),
-                    Err(_) =>
-                        tokens.push(
-                            Token::Symbol(
-                                Content::new(String::from(buffer), current_pos, line.clone())
-                            )
-                        ),
-                }
+    fn flush_buffer(&mut self, hi: usize) {
+        if self.buffer.is_empty() {
+            return;
         }
+        let span = Span {
+            lo: self.buffer_lo,
+            hi: hi as u32,
+        };
+        let token = match self.buffer.parse::<i64>() {
+            Ok(value) => Token::Integer(Content::new(value, span)),
+            Err(_) => Token::Symbol(Content::new(self.buffer.clone(), span)),
+        };
+        self.push_token(token);
+        self.buffer.clear();
+    }
+
+    fn push_to_buffer(&mut self, ch: char, offset: usize) {
+        if self.buffer.is_empty() {
+            self.buffer_lo = offset as u32;
+        }
+        self.buffer.push(ch);
+    }
+
+    fn push_token(&mut self, token: Token) {
+        self.tokens.push(token);
     }
 }

--- a/risp/src/lexer/implementation.rs
+++ b/risp/src/lexer/implementation.rs
@@ -1,22 +1,15 @@
 use super::token::{Content, Span, Token};
 
+#[derive(Default)]
 pub struct Lexer {
     tokens: Vec<Token>,
     buffer: String,
     buffer_lo: u32,
     in_comment: bool,
+    in_string: bool,
 }
 
-impl Default for Lexer {
-    fn default() -> Self {
-        Self {
-            tokens: vec![],
-            buffer: String::new(),
-            buffer_lo: 0,
-            in_comment: false,
-        }
-    }
-}
+type DelimiterVariant = fn(Content<()>) -> Token;
 
 impl Lexer {
     pub fn tokenize(program: &str) -> Vec<Token> {
@@ -29,15 +22,29 @@ impl Lexer {
                 }
                 continue;
             }
+            if lexer.in_string && ch != '"' {
+                lexer.push_to_buffer(ch, ch_offset);
+                continue;
+            }
 
             match ch {
                 '(' => {
-                    lexer.flush_buffer(ch_offset);
-                    lexer.push_token(Token::LParen(Content::new((), Span::at(ch_offset))));
+                    lexer.push_delimiter(Token::LParen, ch_offset);
                 }
                 ')' => {
-                    lexer.flush_buffer(ch_offset);
-                    lexer.push_token(Token::RParen(Content::new((), Span::at(ch_offset))));
+                    lexer.push_delimiter(Token::RParen, ch_offset);
+                }
+                '{' => {
+                    lexer.push_delimiter(Token::LBrace, ch_offset);
+                }
+                '}' => {
+                    lexer.push_delimiter(Token::RBrace, ch_offset);
+                }
+                '[' => {
+                    lexer.push_delimiter(Token::LBracket, ch_offset);
+                }
+                ']' => {
+                    lexer.push_delimiter(Token::RBracket, ch_offset);
                 }
                 ' ' | '\t' | '\n' | '\r' => {
                     lexer.flush_buffer(ch_offset);
@@ -46,14 +53,27 @@ impl Lexer {
                     lexer.flush_buffer(ch_offset);
                     lexer.in_comment = true;
                 }
+                '"' => {
+                    if lexer.in_string {
+                        lexer.flush_buffer(ch_offset + 1);
+                        lexer.in_string = false;
+                    } else {
+                        lexer.push_to_buffer(ch, ch_offset);
+                        lexer.in_string = true;
+                    }
+                }
                 _ => {
                     lexer.push_to_buffer(ch, ch_offset);
                 }
             }
         }
-
         lexer.flush_buffer(program.len());
         lexer.tokens
+    }
+
+    fn push_delimiter(&mut self, variant: DelimiterVariant, ch_offset: usize) {
+        self.flush_buffer(ch_offset);
+        self.push_token(variant(Content::new((), Span::at(ch_offset))));
     }
 
     fn flush_buffer(&mut self, hi: usize) {
@@ -64,14 +84,36 @@ impl Lexer {
             lo: self.buffer_lo,
             hi: hi as u32,
         };
-        let token = match self.buffer.parse::<i64>() {
-            Ok(value) => Token::Integer(Content::new(value, span)),
-            Err(_) => Token::Symbol(Content::new(self.buffer.clone(), span)),
-        };
+        let token = self.classify_buffer(span);
+
         self.push_token(token);
         self.buffer.clear();
     }
 
+    fn classify_buffer(&self, span: Span) -> Token {
+        None.or_else(|| {
+            self.in_string
+                .then(|| Token::String(Content::new(self.buffer[1..].to_string(), span.clone())))
+        })
+        .or_else(|| {
+            self.buffer
+                .starts_with(':')
+                .then(|| Token::Keyword(Content::new(self.buffer[1..].to_string(), span.clone())))
+        })
+        .or_else(|| {
+            self.buffer
+                .parse::<i64>()
+                .ok()
+                .map(|v| Token::Long(Content::new(v, span.clone())))
+        })
+        .or_else(|| {
+            self.buffer
+                .parse::<f64>()
+                .ok()
+                .map(|v| Token::Double(Content::new(v, span.clone())))
+        })
+        .unwrap_or_else(|| Token::Symbol(Content::new(self.buffer.clone(), span)))
+    }
     fn push_to_buffer(&mut self, ch: char, offset: usize) {
         if self.buffer.is_empty() {
             self.buffer_lo = offset as u32;

--- a/risp/src/lexer/mod.rs
+++ b/risp/src/lexer/mod.rs
@@ -1,3 +1,6 @@
-mod implementation;
+pub(crate) mod implementation;
+#[cfg(test)]
 mod test_lexer;
-pub use super::lexer::implementation::Token;
+pub(crate) mod token;
+pub use implementation::Lexer;
+pub use token::{Span, Token};

--- a/risp/src/lexer/mod.rs
+++ b/risp/src/lexer/mod.rs
@@ -1,6 +1,8 @@
 pub(crate) mod implementation;
 #[cfg(test)]
 mod test_lexer;
+#[cfg(test)]
+mod test_token;
 pub(crate) mod token;
 pub use implementation::Lexer;
 pub use token::{Span, Token};

--- a/risp/src/lexer/test_lexer.rs
+++ b/risp/src/lexer/test_lexer.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
-    use crate::lexer::{Lexer, Span, Token};
     use crate::lexer::token::Content;
+    use crate::lexer::{Lexer, Span, Token};
 
     fn span(lo: u32, hi: u32) -> Span {
         Span { lo, hi }
@@ -15,8 +15,8 @@ mod tests {
             vec![
                 Token::LParen(Content::new((), span(0, 1))),
                 Token::Symbol(Content::new("+".to_string(), span(1, 2))),
-                Token::Integer(Content::new(1, span(3, 4))),
-                Token::Integer(Content::new(2, span(5, 6))),
+                Token::Long(Content::new(1, span(3, 4))),
+                Token::Long(Content::new(2, span(5, 6))),
                 Token::RParen(Content::new((), span(6, 7))),
             ]
         );
@@ -33,7 +33,7 @@ mod tests {
                 Token::LParen(Content::new((), span(4, 5))),
                 Token::LParen(Content::new((), span(5, 6))),
                 Token::Symbol(Content::new("x".to_string(), span(6, 7))),
-                Token::Integer(Content::new(10, span(8, 10))),
+                Token::Long(Content::new(10, span(8, 10))),
                 Token::RParen(Content::new((), span(10, 11))),
                 Token::RParen(Content::new((), span(11, 12))),
                 Token::RParen(Content::new((), span(12, 13))),
@@ -72,7 +72,7 @@ mod tests {
     }
 
     #[test]
-    fn tokenizes_multiline_program_startign_with_comment() {
+    fn tokenizes_multiline_program_starting_with_comment() {
         let tokens = Lexer::tokenize(";1234567\n(foo)");
         assert_eq!(
             tokens,
@@ -85,6 +85,107 @@ mod tests {
     }
 
     #[test]
+    fn tokenizes_string_literal() {
+        let tokens = Lexer::tokenize("\"hello world\"");
+        assert_eq!(
+            tokens,
+            vec![Token::String(Content::new(
+                "hello world".to_string(),
+                span(0, 13)
+            ))]
+        );
+    }
+
+    #[test]
+    fn tokenizes_string_in_expression() {
+        let tokens = Lexer::tokenize("(println \"hi\")");
+        assert_eq!(
+            tokens,
+            vec![
+                Token::LParen(Content::new((), span(0, 1))),
+                Token::Symbol(Content::new("println".to_string(), span(1, 8))),
+                Token::String(Content::new("hi".to_string(), span(9, 13))),
+                Token::RParen(Content::new((), span(13, 14))),
+            ]
+        );
+    }
+
+    #[test]
+    fn tokenizes_keyword() {
+        let tokens = Lexer::tokenize(":foo");
+        assert_eq!(
+            tokens,
+            vec![Token::Keyword(Content::new("foo".to_string(), span(0, 4)))]
+        );
+    }
+
+    #[test]
+    fn tokenizes_keyword_in_expression() {
+        let tokens = Lexer::tokenize("(assoc m :key 1)");
+        assert_eq!(
+            tokens,
+            vec![
+                Token::LParen(Content::new((), span(0, 1))),
+                Token::Symbol(Content::new("assoc".to_string(), span(1, 6))),
+                Token::Symbol(Content::new("m".to_string(), span(7, 8))),
+                Token::Keyword(Content::new("key".to_string(), span(9, 13))),
+                Token::Long(Content::new(1, span(14, 15))),
+                Token::RParen(Content::new((), span(15, 16))),
+            ]
+        );
+    }
+
+    #[test]
+    fn tokenizes_vector_literal() {
+        let tokens = Lexer::tokenize("[1 2 3]");
+        assert_eq!(
+            tokens,
+            vec![
+                Token::LBracket(Content::new((), span(0, 1))),
+                Token::Long(Content::new(1, span(1, 2))),
+                Token::Long(Content::new(2, span(3, 4))),
+                Token::Long(Content::new(3, span(5, 6))),
+                Token::RBracket(Content::new((), span(6, 7))),
+            ]
+        );
+    }
+
+    #[test]
+    fn tokenizes_map_literal() {
+        let tokens = Lexer::tokenize("{:a 1}");
+        assert_eq!(
+            tokens,
+            vec![
+                Token::LBrace(Content::new((), span(0, 1))),
+                Token::Keyword(Content::new("a".to_string(), span(1, 3))),
+                Token::Long(Content::new(1, span(4, 5))),
+                Token::RBrace(Content::new((), span(5, 6))),
+            ]
+        );
+    }
+
+    #[test]
+    fn tokenizes_double_literal() {
+        let tokens = Lexer::tokenize("3.14");
+        assert_eq!(tokens, vec![Token::Double(Content::new(3.14, span(0, 4)))]);
+    }
+
+    #[test]
+    fn tokenizes_double_in_expression() {
+        let tokens = Lexer::tokenize("(+ 1 2.5)");
+        assert_eq!(
+            tokens,
+            vec![
+                Token::LParen(Content::new((), span(0, 1))),
+                Token::Symbol(Content::new("+".to_string(), span(1, 2))),
+                Token::Long(Content::new(1, span(3, 4))),
+                Token::Double(Content::new(2.5, span(5, 8))),
+                Token::RParen(Content::new((), span(8, 9))),
+            ]
+        );
+    }
+
+    #[test]
     fn empty_input_produces_no_tokens() {
         assert_eq!(Lexer::tokenize(""), vec![]);
     }
@@ -92,75 +193,5 @@ mod tests {
     #[test]
     fn only_whitespace_produces_no_tokens() {
         assert_eq!(Lexer::tokenize("   \t\n  "), vec![]);
-    }
-
-    #[test]
-    fn span_covers_token_at_end_of_input() {
-        let tokens = Lexer::tokenize("hello");
-        assert_eq!(tokens.len(), 1);
-        let s = match &tokens[0] {
-            Token::Symbol(c) => &c.span,
-            t => panic!("expected Symbol, got {:?}", t),
-        };
-        assert_eq!(s.lo, 0);
-        assert_eq!(s.hi, 5);
-    }
-
-    #[test]
-    fn span_of_integer_is_exact() {
-        let tokens = Lexer::tokenize(" 314 ");
-        assert_eq!(tokens.len(), 1);
-        let s = match &tokens[0] {
-            Token::Integer(c) => &c.span,
-            t => panic!("expected Integer, got {:?}", t),
-        };
-        assert_eq!(s.lo, 1);
-        assert_eq!(s.hi, 4);
-    }
-
-    #[test]
-    fn token_display_format() {
-        assert_eq!(
-            format!("{}", Token::LParen(Content::new((), span(0, 1)))),
-            "0..1 LParen"
-        );
-        assert_eq!(
-            format!("{}", Token::RParen(Content::new((), span(6, 7)))),
-            "6..7 RParen"
-        );
-        assert_eq!(
-            format!(
-                "{}",
-                Token::Symbol(Content::new("+".to_string(), span(1, 2)))
-            ),
-            "1..2 Symbol(+)"
-        );
-        assert_eq!(
-            format!("{}", Token::Integer(Content::new(42, span(3, 5)))),
-            "3..5 Int(42)"
-        );
-    }
-
-    #[test]
-    fn token_debug_format() {
-        assert_eq!(
-            format!("{:?}", Token::LParen(Content::new((), span(0, 1)))),
-            "0..1 LParen"
-        );
-        assert_eq!(
-            format!("{:?}", Token::RParen(Content::new((), span(6, 7)))),
-            "6..7 RParen"
-        );
-        assert_eq!(
-            format!(
-                "{:?}",
-                Token::Symbol(Content::new("+".to_string(), span(1, 2)))
-            ),
-            "1..2 Symbol(+)"
-        );
-        assert_eq!(
-            format!("{:?}", Token::Integer(Content::new(42, span(3, 5)))),
-            "3..5 Int(42)"
-        );
     }
 }

--- a/risp/src/lexer/test_lexer.rs
+++ b/risp/src/lexer/test_lexer.rs
@@ -1,98 +1,166 @@
 #[cfg(test)]
-use super::implementation::{ Token, Content };
+mod tests {
+    use crate::lexer::{Lexer, Span, Token};
+    use crate::lexer::token::Content;
 
-#[test]
-fn test_add() {
-    let tokens = Token::tokenize("(+ 1 2)");
-    assert_eq!(
-        tokens,
-        vec![
-            Token::LParen(Content::new((), 0, 1)),
-            Token::Symbol(Content::new("+".to_string(), 1, 1)),
-            Token::Integer(Content::new(1, 3, 1)),
-            Token::Integer(Content::new(2, 5, 1)),
-            Token::RParen(Content::new((), 6, 1))
-        ]
-    )
-}
+    fn span(lo: u32, hi: u32) -> Span {
+        Span { lo, hi }
+    }
 
-#[test]
-fn test_area_of_a_circle() {
-    let program = "
-    (
-     (let r 10)
-     (let pi 314)
-     (* pi (* r r))
-    )
-    ";
-    let tokens = Token::tokenize(program);
-    assert_eq!(
-        tokens,
-        vec![
-            Token::LParen(Content::new((), 5, 1)),
-            Token::LParen(Content::new((), 6, 2)),
-            Token::Symbol(Content::new("let".to_string(), 7, 2)),
-            Token::Symbol(Content::new("r".to_string(), 11, 2)),
-            Token::Integer(Content::new(10, 13, 2)),
-            Token::RParen(Content::new((), 15, 2)),
-            Token::LParen(Content::new((), 6, 3)),
-            Token::Symbol(Content::new("let".to_string(), 7, 3)),
-            Token::Symbol(Content::new("pi".to_string(), 1, 3)),
-            Token::Integer(Content::new(314, 14, 3)),
-            Token::RParen(Content::new((), 17, 3)),
-            Token::LParen(Content::new((), 6, 4)),
-            Token::Symbol(Content::new("*".to_string(), 7, 4)),
-            Token::Symbol(Content::new("pi".to_string(), 9, 4)),
-            Token::LParen(Content::new((), 12, 4)),
-            Token::Symbol(Content::new("*".to_string(), 13, 4)),
-            Token::Symbol(Content::new("r".to_string(), 15, 4)),
-            Token::Symbol(Content::new("r".to_string(), 17, 4)),
-            Token::RParen(Content::new((), 18, 4)),
-            Token::RParen(Content::new((), 19, 4)),
-            Token::RParen(Content::new((), 5, 5))
-        ]
-    );
-}
+    #[test]
+    fn tokenizes_arithmetic_expression() {
+        let tokens = Lexer::tokenize("(+ 1 2)");
+        assert_eq!(
+            tokens,
+            vec![
+                Token::LParen(Content::new((), span(0, 1))),
+                Token::Symbol(Content::new("+".to_string(), span(1, 2))),
+                Token::Integer(Content::new(1, span(3, 4))),
+                Token::Integer(Content::new(2, span(5, 6))),
+                Token::RParen(Content::new((), span(6, 7))),
+            ]
+        );
+    }
 
-#[test]
-fn test_let_withou_space() {
-    let program = "(let((x 10)))";
-    let tokens = Token::tokenize(program);
+    #[test]
+    fn tokenizes_consecutive_delimiters() {
+        let tokens = Lexer::tokenize("(let((x 10)))");
+        assert_eq!(
+            tokens,
+            vec![
+                Token::LParen(Content::new((), span(0, 1))),
+                Token::Symbol(Content::new("let".to_string(), span(1, 4))),
+                Token::LParen(Content::new((), span(4, 5))),
+                Token::LParen(Content::new((), span(5, 6))),
+                Token::Symbol(Content::new("x".to_string(), span(6, 7))),
+                Token::Integer(Content::new(10, span(8, 10))),
+                Token::RParen(Content::new((), span(10, 11))),
+                Token::RParen(Content::new((), span(11, 12))),
+                Token::RParen(Content::new((), span(12, 13))),
+            ]
+        );
+    }
 
-    assert_eq!(
-        tokens,
-        vec![
-            Token::LParen(Content::new((), 1, 0)),
-            Token::Symbol(Content::new("let".to_string(), 2, 0)),
-            Token::LParen(Content::new((), 5, 0)),
-            Token::LParen(Content::new((), 6, 0)),
-            Token::Symbol(Content::new("x".to_string(), 7, 0)),
-            Token::Integer(Content::new(10, 9, 0)),
-            Token::RParen(Content::new((), 11, 0)),
-            Token::RParen(Content::new((), 12, 0)),
-            Token::RParen(Content::new((), 13, 0))
-        ]
-    );
-}
+    #[test]
+    fn tokenizes_multiline_program() {
+        let tokens = Lexer::tokenize("(foo\n bar)");
+        assert_eq!(
+            tokens,
+            vec![
+                Token::LParen(Content::new((), span(0, 1))),
+                Token::Symbol(Content::new("foo".to_string(), span(1, 4))),
+                Token::Symbol(Content::new("bar".to_string(), span(6, 9))),
+                Token::RParen(Content::new((), span(9, 10))),
+            ]
+        );
+    }
 
-#[test]
-fn test_debug_token_debug_trait() {
-    assert_eq!(format!("{:?}", Token::LParen(Content::new((), 0, 0))), "0:0 LParen");
-    assert_eq!(
-        format!("{:?}", Token::Symbol(Content::new("let".to_string(), 0, 0))),
-        "0:0 Symbol(let)"
-    );
-    assert_eq!(format!("{:?}", Token::Integer(Content::new(10, 0, 0))), "0:0 Int(10)");
-    assert_eq!(format!("{:?}", Token::RParen(Content::new((), 0, 0))), "0:0 RParen");
-}
+    #[test]
+    fn tokenizes_multiline_program_with_comment() {
+        let tokens = Lexer::tokenize("(foo)\n(bar);(bla)");
+        assert_eq!(
+            tokens,
+            vec![
+                Token::LParen(Content::new((), span(0, 1))),
+                Token::Symbol(Content::new("foo".to_string(), span(1, 4))),
+                Token::RParen(Content::new((), span(4, 5))),
+                Token::LParen(Content::new((), span(6, 7))),
+                Token::Symbol(Content::new("bar".to_string(), span(7, 10))),
+                Token::RParen(Content::new((), span(10, 11))),
+            ]
+        );
+    }
 
-#[test]
-fn test_debug_token_display_trait() {
-    assert_eq!(format!("{}", Token::LParen(Content::new((), 0, 0))), "0:0 LParen");
-    assert_eq!(
-        format!("{}", Token::Symbol(Content::new("let".to_string(), 0, 0))),
-        "0:0 Symbol(let)"
-    );
-    assert_eq!(format!("{}", Token::Integer(Content::new(10, 0, 0))), "0:0 Int(10)");
-    assert_eq!(format!("{}", Token::RParen(Content::new((), 0, 0))), "0:0 RParen");
+    #[test]
+    fn tokenizes_multiline_program_startign_with_comment() {
+        let tokens = Lexer::tokenize(";1234567\n(foo)");
+        assert_eq!(
+            tokens,
+            vec![
+                Token::LParen(Content::new((), span(10, 11))),
+                Token::Symbol(Content::new("foo".to_string(), span(11, 14))),
+                Token::RParen(Content::new((), span(14, 15))),
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_input_produces_no_tokens() {
+        assert_eq!(Lexer::tokenize(""), vec![]);
+    }
+
+    #[test]
+    fn only_whitespace_produces_no_tokens() {
+        assert_eq!(Lexer::tokenize("   \t\n  "), vec![]);
+    }
+
+    #[test]
+    fn span_covers_token_at_end_of_input() {
+        let tokens = Lexer::tokenize("hello");
+        assert_eq!(tokens.len(), 1);
+        let s = match &tokens[0] {
+            Token::Symbol(c) => &c.span,
+            t => panic!("expected Symbol, got {:?}", t),
+        };
+        assert_eq!(s.lo, 0);
+        assert_eq!(s.hi, 5);
+    }
+
+    #[test]
+    fn span_of_integer_is_exact() {
+        let tokens = Lexer::tokenize(" 314 ");
+        assert_eq!(tokens.len(), 1);
+        let s = match &tokens[0] {
+            Token::Integer(c) => &c.span,
+            t => panic!("expected Integer, got {:?}", t),
+        };
+        assert_eq!(s.lo, 1);
+        assert_eq!(s.hi, 4);
+    }
+
+    #[test]
+    fn token_display_format() {
+        assert_eq!(
+            format!("{}", Token::LParen(Content::new((), span(0, 1)))),
+            "0..1 LParen"
+        );
+        assert_eq!(
+            format!("{}", Token::RParen(Content::new((), span(6, 7)))),
+            "6..7 RParen"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Token::Symbol(Content::new("+".to_string(), span(1, 2)))
+            ),
+            "1..2 Symbol(+)"
+        );
+        assert_eq!(
+            format!("{}", Token::Integer(Content::new(42, span(3, 5)))),
+            "3..5 Int(42)"
+        );
+    }
+
+    #[test]
+    fn token_debug_format() {
+        assert_eq!(
+            format!("{:?}", Token::LParen(Content::new((), span(0, 1)))),
+            "0..1 LParen"
+        );
+        assert_eq!(
+            format!("{:?}", Token::RParen(Content::new((), span(6, 7)))),
+            "6..7 RParen"
+        );
+        assert_eq!(
+            format!(
+                "{:?}",
+                Token::Symbol(Content::new("+".to_string(), span(1, 2)))
+            ),
+            "1..2 Symbol(+)"
+        );
+        assert_eq!(
+            format!("{:?}", Token::Integer(Content::new(42, span(3, 5)))),
+            "3..5 Int(42)"
+        );
+    }
 }

--- a/risp/src/lexer/test_token.rs
+++ b/risp/src/lexer/test_token.rs
@@ -1,0 +1,141 @@
+#[cfg(test)]
+mod tests {
+    use crate::lexer::token::Content;
+    use crate::lexer::{Span, Token};
+
+    fn span(lo: u32, hi: u32) -> Span {
+        Span { lo, hi }
+    }
+
+    #[test]
+    fn span_covers_token_at_end_of_input() {
+        use crate::lexer::Lexer;
+        let tokens = Lexer::tokenize("hello");
+        assert_eq!(tokens.len(), 1);
+        let s = match &tokens[0] {
+            Token::Symbol(c) => &c.span,
+            t => panic!("expected Symbol, got {:?}", t),
+        };
+        assert_eq!(s.lo, 0);
+        assert_eq!(s.hi, 5);
+    }
+
+    #[test]
+    fn span_of_integer_is_exact() {
+        use crate::lexer::Lexer;
+        let tokens = Lexer::tokenize(" 314 ");
+        assert_eq!(tokens.len(), 1);
+        let s = match &tokens[0] {
+            Token::Long(c) => &c.span,
+            t => panic!("expected Integer, got {:?}", t),
+        };
+        assert_eq!(s.lo, 1);
+        assert_eq!(s.hi, 4);
+    }
+
+    #[test]
+    fn token_display_format() {
+        assert_eq!(
+            format!("{}", Token::LParen(Content::new((), span(0, 1)))),
+            "0..1 LParen"
+        );
+        assert_eq!(
+            format!("{}", Token::RParen(Content::new((), span(6, 7)))),
+            "6..7 RParen"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Token::Symbol(Content::new("+".to_string(), span(1, 2)))
+            ),
+            "1..2 Symbol(+)"
+        );
+        assert_eq!(
+            format!("{}", Token::Long(Content::new(42, span(3, 5)))),
+            "3..5 Long(42)"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Token::Keyword(Content::new("foo".to_string(), span(0, 4)))
+            ),
+            "0..4 Keyword(foo)"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Token::String(Content::new("hello".to_string(), span(0, 7)))
+            ),
+            "0..7 String(hello)"
+        );
+        assert_eq!(
+            format!("{}", Token::LBracket(Content::new((), span(0, 1)))),
+            "0..1 LBracket"
+        );
+        assert_eq!(
+            format!("{}", Token::RBracket(Content::new((), span(1, 2)))),
+            "1..2 RBracket"
+        );
+        assert_eq!(
+            format!("{}", Token::LBrace(Content::new((), span(0, 1)))),
+            "0..1 LBrace"
+        );
+        assert_eq!(
+            format!("{}", Token::RBrace(Content::new((), span(1, 2)))),
+            "1..2 RBrace"
+        );
+    }
+
+    #[test]
+    fn token_debug_format() {
+        assert_eq!(
+            format!("{:?}", Token::LParen(Content::new((), span(0, 1)))),
+            "0..1 LParen"
+        );
+        assert_eq!(
+            format!("{:?}", Token::RParen(Content::new((), span(6, 7)))),
+            "6..7 RParen"
+        );
+        assert_eq!(
+            format!(
+                "{:?}",
+                Token::Symbol(Content::new("+".to_string(), span(1, 2)))
+            ),
+            "1..2 Symbol(+)"
+        );
+        assert_eq!(
+            format!("{:?}", Token::Long(Content::new(42, span(3, 5)))),
+            "3..5 Long(42)"
+        );
+        assert_eq!(
+            format!(
+                "{:?}",
+                Token::Keyword(Content::new("foo".to_string(), span(0, 4)))
+            ),
+            "0..4 Keyword(foo)"
+        );
+        assert_eq!(
+            format!(
+                "{:?}",
+                Token::String(Content::new("hello".to_string(), span(0, 7)))
+            ),
+            "0..7 String(hello)"
+        );
+        assert_eq!(
+            format!("{:?}", Token::LBracket(Content::new((), span(0, 1)))),
+            "0..1 LBracket"
+        );
+        assert_eq!(
+            format!("{:?}", Token::RBracket(Content::new((), span(1, 2)))),
+            "1..2 RBracket"
+        );
+        assert_eq!(
+            format!("{:?}", Token::LBrace(Content::new((), span(0, 1)))),
+            "0..1 LBrace"
+        );
+        assert_eq!(
+            format!("{:?}", Token::RBrace(Content::new((), span(1, 2)))),
+            "1..2 RBrace"
+        );
+    }
+}

--- a/risp/src/lexer/token.rs
+++ b/risp/src/lexer/token.rs
@@ -17,13 +17,7 @@ where
     T: Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{lo}..{hi} {content}",
-            lo = self.span.lo,
-            hi = self.span.hi,
-            content = format!("{:?}", self.content)
-        )
+        write!(f, "{}..{} {:?}", self.span.lo, self.span.hi, self.content)
     }
 }
 
@@ -32,13 +26,7 @@ where
     T: Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{lo}..{hi} {content}",
-            lo = self.span.lo,
-            hi = self.span.hi,
-            content = format!("{:?}", self.content)
-        )
+        write!(f, "{}..{} {:?}", self.span.lo, self.span.hi, self.content)
     }
 }
 
@@ -70,18 +58,32 @@ impl<T> Content<T> {
 
 #[derive(PartialEq, Clone)]
 pub enum Token {
-    Integer(Content<i64>),
+    Long(Content<i64>),
+    Double(Content<f64>),
     Symbol(Content<String>),
+    String(Content<String>),
+    Keyword(Content<String>),
     LParen(Content<()>),
     RParen(Content<()>),
+    LBracket(Content<()>),
+    RBracket(Content<()>),
+    LBrace(Content<()>),
+    RBrace(Content<()>),
 }
 
 impl Display for Token {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Token::Integer(c) => write!(
+            Token::Long(c) => write!(
                 f,
-                "{lo}..{hi} Int({value})",
+                "{lo}..{hi} Long({value})",
+                lo = c.span.lo,
+                hi = c.span.hi,
+                value = c.content
+            ),
+            Token::Double(c) => write!(
+                f,
+                "{lo}..{hi} Double({value})",
                 lo = c.span.lo,
                 hi = c.span.hi,
                 value = c.content
@@ -95,6 +97,25 @@ impl Display for Token {
             ),
             Token::LParen(c) => write!(f, "{lo}..{hi} LParen", lo = c.span.lo, hi = c.span.hi),
             Token::RParen(c) => write!(f, "{lo}..{hi} RParen", lo = c.span.lo, hi = c.span.hi),
+            Token::Keyword(c) => write!(
+                f,
+                "{lo}..{hi} Keyword({value})",
+                lo = c.span.lo,
+                hi = c.span.hi,
+                value = c.content
+            ),
+            Token::String(c) => write!(
+                f,
+                "{lo}..{hi} String({value})",
+                lo = c.span.lo,
+                hi = c.span.hi,
+                value = c.content
+            ),
+
+            Token::LBracket(c) => write!(f, "{lo}..{hi} LBracket", lo = c.span.lo, hi = c.span.hi),
+            Token::RBracket(c) => write!(f, "{lo}..{hi} RBracket", lo = c.span.lo, hi = c.span.hi),
+            Token::LBrace(c) => write!(f, "{lo}..{hi} LBrace", lo = c.span.lo, hi = c.span.hi),
+            Token::RBrace(c) => write!(f, "{lo}..{hi} RBrace", lo = c.span.lo, hi = c.span.hi),
         }
     }
 }
@@ -102,9 +123,16 @@ impl Display for Token {
 impl Debug for Token {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Token::Integer(c) => write!(
+            Token::Long(c) => write!(
                 f,
-                "{lo}..{hi} Int({value})",
+                "{lo}..{hi} Long({value})",
+                lo = c.span.lo,
+                hi = c.span.hi,
+                value = c.content
+            ),
+            Token::Double(c) => write!(
+                f,
+                "{lo}..{hi} Double({value})",
                 lo = c.span.lo,
                 hi = c.span.hi,
                 value = c.content
@@ -118,6 +146,24 @@ impl Debug for Token {
             ),
             Token::LParen(c) => write!(f, "{lo}..{hi} LParen", lo = c.span.lo, hi = c.span.hi),
             Token::RParen(c) => write!(f, "{lo}..{hi} RParen", lo = c.span.lo, hi = c.span.hi),
+            Token::Keyword(c) => write!(
+                f,
+                "{lo}..{hi} Keyword({value})",
+                lo = c.span.lo,
+                hi = c.span.hi,
+                value = c.content
+            ),
+            Token::String(c) => write!(
+                f,
+                "{lo}..{hi} String({value})",
+                lo = c.span.lo,
+                hi = c.span.hi,
+                value = c.content
+            ),
+            Token::LBracket(c) => write!(f, "{lo}..{hi} LBracket", lo = c.span.lo, hi = c.span.hi),
+            Token::RBracket(c) => write!(f, "{lo}..{hi} RBracket", lo = c.span.lo, hi = c.span.hi),
+            Token::LBrace(c) => write!(f, "{lo}..{hi} LBrace", lo = c.span.lo, hi = c.span.hi),
+            Token::RBrace(c) => write!(f, "{lo}..{hi} RBrace", lo = c.span.lo, hi = c.span.hi),
         }
     }
 }

--- a/risp/src/lexer/token.rs
+++ b/risp/src/lexer/token.rs
@@ -6,6 +6,15 @@ pub struct Span {
     pub hi: u32,
 }
 
+impl Span {
+    pub fn full(&self, other: Self) -> Self {
+        Self {
+            lo: self.lo,
+            hi: other.hi,
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct Content<T> {
     pub content: T,

--- a/risp/src/lexer/token.rs
+++ b/risp/src/lexer/token.rs
@@ -1,0 +1,123 @@
+use std::fmt::{Debug, Display};
+
+#[derive(Clone, Debug)]
+pub struct Span {
+    pub lo: u32,
+    pub hi: u32,
+}
+
+#[derive(Clone)]
+pub struct Content<T> {
+    pub content: T,
+    pub span: Span,
+}
+
+impl<T> Display for Content<T>
+where
+    T: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{lo}..{hi} {content}",
+            lo = self.span.lo,
+            hi = self.span.hi,
+            content = format!("{:?}", self.content)
+        )
+    }
+}
+
+impl<T> Debug for Content<T>
+where
+    T: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{lo}..{hi} {content}",
+            lo = self.span.lo,
+            hi = self.span.hi,
+            content = format!("{:?}", self.content)
+        )
+    }
+}
+
+impl<T> PartialEq for Content<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.content == other.content
+    }
+}
+
+impl<T> Eq for Content<T> where T: Eq {}
+
+impl Span {
+    pub fn at(offset: usize) -> Self {
+        Span {
+            lo: offset as u32,
+            hi: (offset + 1) as u32,
+        }
+    }
+}
+
+impl<T> Content<T> {
+    pub fn new(content: T, span: Span) -> Self {
+        Content { content, span }
+    }
+}
+
+#[derive(PartialEq, Clone)]
+pub enum Token {
+    Integer(Content<i64>),
+    Symbol(Content<String>),
+    LParen(Content<()>),
+    RParen(Content<()>),
+}
+
+impl Display for Token {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Token::Integer(c) => write!(
+                f,
+                "{lo}..{hi} Int({value})",
+                lo = c.span.lo,
+                hi = c.span.hi,
+                value = c.content
+            ),
+            Token::Symbol(c) => write!(
+                f,
+                "{lo}..{hi} Symbol({value})",
+                lo = c.span.lo,
+                hi = c.span.hi,
+                value = c.content
+            ),
+            Token::LParen(c) => write!(f, "{lo}..{hi} LParen", lo = c.span.lo, hi = c.span.hi),
+            Token::RParen(c) => write!(f, "{lo}..{hi} RParen", lo = c.span.lo, hi = c.span.hi),
+        }
+    }
+}
+
+impl Debug for Token {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Token::Integer(c) => write!(
+                f,
+                "{lo}..{hi} Int({value})",
+                lo = c.span.lo,
+                hi = c.span.hi,
+                value = c.content
+            ),
+            Token::Symbol(c) => write!(
+                f,
+                "{lo}..{hi} Symbol({value})",
+                lo = c.span.lo,
+                hi = c.span.hi,
+                value = c.content
+            ),
+            Token::LParen(c) => write!(f, "{lo}..{hi} LParen", lo = c.span.lo, hi = c.span.hi),
+            Token::RParen(c) => write!(f, "{lo}..{hi} RParen", lo = c.span.lo, hi = c.span.hi),
+        }
+    }
+}

--- a/risp/src/parser/ast.rs
+++ b/risp/src/parser/ast.rs
@@ -1,0 +1,46 @@
+use crate::lexer::Span;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ExprKind {
+    Long(i64),
+    Double(f64),
+    Bool(bool),
+    Nil,
+    String(String),
+    Keyword(String),
+    Symbol(String),
+
+    List(Vec<ExprKind>),
+    Vector(Vec<ExprKind>),
+    Map(Vec<(ExprKind, ExprKind)>),
+}
+
+#[derive(Debug, Clone)]
+pub struct Expr {
+    pub kind: ExprKind,
+    pub span: Span,
+}
+
+impl Expr {
+    pub fn new(kind: ExprKind, span: Span) -> Self {
+        Expr { kind, span }
+    }
+}
+
+impl PartialEq for Expr {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind
+    }
+}
+
+#[derive(Debug)]
+pub enum ParseError {
+    UnmatchedOpen(Span),
+    UnmatchedClose(char, Span),
+    MismatchedDelimiter {
+        expected: char,
+        found: char,
+        span: Span,
+    },
+    OddMapElements(Span),
+}

--- a/risp/src/parser/cst.rs
+++ b/risp/src/parser/cst.rs
@@ -10,9 +10,9 @@ pub enum ExprKind {
     Keyword(String),
     Symbol(String),
 
-    List(Vec<ExprKind>),
-    Vector(Vec<ExprKind>),
-    Map(Vec<(ExprKind, ExprKind)>),
+    List(Vec<Expr>),
+    Vector(Vec<Expr>),
+    Map(Vec<(Expr, Expr)>),
 }
 
 #[derive(Debug, Clone)]
@@ -31,16 +31,4 @@ impl PartialEq for Expr {
     fn eq(&self, other: &Self) -> bool {
         self.kind == other.kind
     }
-}
-
-#[derive(Debug)]
-pub enum ParseError {
-    UnmatchedOpen(Span),
-    UnmatchedClose(char, Span),
-    MismatchedDelimiter {
-        expected: char,
-        found: char,
-        span: Span,
-    },
-    OddMapElements(Span),
 }

--- a/risp/src/parser/implementation.rs
+++ b/risp/src/parser/implementation.rs
@@ -1,6 +1,5 @@
 use crate::evaluator::SysCallWrapper;
 use crate::lexer::{Span, Token};
-use crate::parser::ast::{Expr, ParseError};
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Object {
@@ -182,8 +181,4 @@ impl std::fmt::Display for Object {
             _ => Ok(()),
         }
     }
-}
-
-pub fn parse(tokens: Vec<Token>) -> Result<Vec<Expr>, ParseError> {
-    Ok([])
 }

--- a/risp/src/parser/implementation.rs
+++ b/risp/src/parser/implementation.rs
@@ -44,27 +44,39 @@ impl Object {
                         }
                     }
                 }
-                Token::Integer(n) => {
+                Token::Long(n) => {
                     if let Some(last) = stack.last_mut() {
                         last.push(Object::Integer(n.content));
                     }
                 }
+                Token::Double(_) => {
+                    // TODO: implement float support in Object
+                }
+                Token::Keyword(k) => {
+                    if let Some(last) = stack.last_mut() {
+                        last.push(Object::Symbol(format!(":{}", k.content)));
+                    }
+                }
+                Token::String(s) => {
+                    if let Some(last) = stack.last_mut() {
+                        last.push(Object::String(s.content));
+                    }
+                }
+                Token::LBracket(_) | Token::RBracket(_) | Token::LBrace(_) | Token::RBrace(_) => {
+                    // TODO: implement vector and map parsing
+                }
                 Token::Symbol(s) => {
                     let content = s.content.clone();
-                    let has_double_quotes =
-                        content.chars().next() == Some('"') && content.chars().last() == Some('"');
-                    let has_single_quote = content.chars().next() == Some('\'')
-                        && content.chars().last() == Some('\'');
+                    let has_double_quotes = content.starts_with('"') && content.ends_with('"');
+                    let has_single_quote = content.starts_with('\'') && content.ends_with('\'');
 
                     if has_double_quotes || has_single_quote {
                         if let Some(last) = stack.last_mut() {
                             let content_without_quotes = content[1..content.len() - 1].to_string();
                             last.push(Object::String(content_without_quotes));
                         }
-                    } else {
-                        if let Some(last) = stack.last_mut() {
-                            last.push(Object::Symbol(content));
-                        }
+                    } else if let Some(last) = stack.last_mut() {
+                        last.push(Object::Symbol(content));
                     }
                 }
             }
@@ -81,7 +93,7 @@ impl Object {
         match final_list {
             Some(ref mut list) => {
                 if list.len() == 1 {
-                    return Ok(list[0].clone());
+                    Ok(list[0].clone())
                 } else {
                     Ok(Object::Void)
                 }

--- a/risp/src/parser/implementation.rs
+++ b/risp/src/parser/implementation.rs
@@ -1,5 +1,6 @@
 use crate::evaluator::SysCallWrapper;
 use crate::lexer::{Span, Token};
+use crate::parser::ast::{Expr, ParseError};
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Object {
@@ -181,4 +182,8 @@ impl std::fmt::Display for Object {
             _ => Ok(()),
         }
     }
+}
+
+pub fn parse(tokens: Vec<Token>) -> Result<Vec<Expr>, ParseError> {
+    Ok([])
 }

--- a/risp/src/parser/implementation.rs
+++ b/risp/src/parser/implementation.rs
@@ -1,5 +1,5 @@
 use crate::evaluator::SysCallWrapper;
-use crate::lexer::Token;
+use crate::lexer::{Span, Token};
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Object {
@@ -71,11 +71,9 @@ impl Object {
         }
 
         if !parenthesis_counter.is_balanced() {
-            let (ch, line) = parenthesis_counter.last_ch_and_line();
             return Err(ParserError {
                 err: "Unmatched opening parenthesis".to_string(),
-                ch,
-                line,
+                span: parenthesis_counter.last_span(),
             });
         }
 
@@ -111,8 +109,7 @@ impl ParenthesisCounter {
                 if self.parens.is_empty() {
                     return Err(ParserError {
                         err: "Unmatched closing parenthesis".to_string(),
-                        ch: c.ch,
-                        line: c.line,
+                        span: c.span.clone(),
                     });
                 }
                 self.parens.pop();
@@ -122,11 +119,10 @@ impl ParenthesisCounter {
         Ok(())
     }
 
-    pub fn last_ch_and_line(&self) -> (usize, usize) {
+    pub fn last_span(&self) -> Span {
         match self.parens.last() {
-            Some(Token::LParen(c)) => (c.ch, c.line),
-            Some(_) => (0, 0), // Unreachable code
-            None => (0, 0),
+            Some(Token::LParen(c)) => c.span.clone(),
+            _ => Span { lo: 0, hi: 0 },
         }
     }
 
@@ -138,17 +134,16 @@ impl ParenthesisCounter {
 #[derive(Debug)]
 pub struct ParserError {
     err: String,
-    ch: usize,
-    line: usize,
+    span: Span,
 }
 
 impl std::fmt::Display for ParserError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{line}:{ch} {err}",
-            line = self.line,
-            ch = self.ch,
+            "@{lo}..{hi} {err}",
+            lo = self.span.lo,
+            hi = self.span.hi,
             err = self.err
         )
     }

--- a/risp/src/parser/mod.rs
+++ b/risp/src/parser/mod.rs
@@ -1,5 +1,9 @@
-mod ast;
+mod cst;
 mod implementation;
+mod parser_impl;
 mod test_parser;
+#[cfg(test)]
+mod test_parser_impl;
 
 pub use crate::parser::implementation::Object;
+pub use crate::parser::parser_impl::Parser;

--- a/risp/src/parser/mod.rs
+++ b/risp/src/parser/mod.rs
@@ -1,3 +1,4 @@
+mod ast;
 mod implementation;
 mod test_parser;
 

--- a/risp/src/parser/parser_impl.rs
+++ b/risp/src/parser/parser_impl.rs
@@ -1,0 +1,160 @@
+use crate::lexer::token::Content;
+use crate::lexer::{Span, Token};
+use crate::parser::cst::{Expr, ExprKind};
+
+#[derive(Debug)]
+pub enum ParseError {
+    UnmatchedOpen(Span),
+    UnmatchedClose(char, Span),
+    MismatchedDelimiter {
+        expected: char,
+        found: char,
+        span: Span,
+    },
+    OddMapElements(Span),
+}
+
+#[derive(Debug)]
+pub enum Frame {
+    List(Vec<Expr>, Span),
+    Vector(Vec<Expr>, Span),
+    Map(Vec<Expr>, Span),
+}
+
+#[derive(Debug)]
+pub struct Parser {
+    tokens: Vec<Token>,
+    stack: Vec<Frame>,
+    result: Vec<Expr>,
+}
+
+impl Parser {
+    fn new(tokens: Vec<Token>) -> Self {
+        Self {
+            tokens: tokens.into_iter().rev().collect::<Vec<Token>>(),
+            stack: vec![],
+            result: vec![],
+        }
+    }
+
+    pub fn parse(tokens: Vec<Token>) -> Result<Vec<Expr>, ParseError> {
+        let parser = Self::new(tokens);
+        parser.run()
+    }
+
+    fn run(mut self) -> Result<Vec<Expr>, ParseError> {
+        while let Some(token) = self.tokens.pop() {
+            match token {
+                Token::LParen(c) => self.stack.push(Frame::List(vec![], c.span)),
+                Token::RParen(c) => self.parse_r_paren(c.span)?,
+                Token::LBracket(c) => self.stack.push(Frame::Vector(vec![], c.span)),
+                Token::RBracket(c) => self.parse_r_bracket(c.span)?,
+                Token::LBrace(c) => self.stack.push(Frame::Map(vec![], c.span)),
+                Token::RBrace(c) => self.parse_r_brace(c.span)?,
+                Token::Long(c) => self.push_to_frame(ExprKind::Long(c.content), c.span)?,
+                Token::Double(c) => self.push_to_frame(ExprKind::Double(c.content), c.span)?,
+                Token::Symbol(c) => self.parse_symbol(c)?,
+                Token::String(c) => self.push_to_frame(ExprKind::String(c.content), c.span)?,
+                Token::Keyword(c) => self.push_to_frame(ExprKind::Keyword(c.content), c.span)?,
+            }
+        }
+
+        if let Some(frame) = self.stack.last() {
+            let span = match frame {
+                Frame::List(_, s) | Frame::Vector(_, s) | Frame::Map(_, s) => s.clone(),
+            };
+            return Err(ParseError::UnmatchedOpen(span));
+        }
+
+        Ok(self.result)
+    }
+
+    fn parse_symbol(&mut self, c: Content<String>) -> Result<(), ParseError> {
+        let kind = match c.content.as_str() {
+            "true" => ExprKind::Bool(true),
+            "false" => ExprKind::Bool(false),
+            "nil" => ExprKind::Nil,
+            _ => ExprKind::Symbol(c.content),
+        };
+        self.push_to_frame(kind, c.span)
+    }
+
+    fn push_to_frame(&mut self, expr_kind: ExprKind, span: Span) -> Result<(), ParseError> {
+        let expr = Expr {
+            kind: expr_kind,
+            span,
+        };
+        match self.stack.last_mut() {
+            Some(Frame::List(elems, _)) => elems.push(expr),
+            Some(Frame::Vector(elems, _)) => elems.push(expr),
+            Some(Frame::Map(elems, _)) => elems.push(expr),
+            None => self.result.push(expr),
+        }
+        Ok(())
+    }
+
+    fn parse_r_paren(&mut self, current_span: Span) -> Result<(), ParseError> {
+        match self.stack.pop() {
+            Some(Frame::List(elems, span)) => {
+                self.push_to_frame(ExprKind::List(elems), span.full(current_span))
+            }
+            Some(Frame::Vector(_, span)) => Err(ParseError::MismatchedDelimiter {
+                expected: ']',
+                found: ')',
+                span,
+            }),
+            Some(Frame::Map(_, span)) => Err(ParseError::MismatchedDelimiter {
+                expected: '}',
+                found: ')',
+                span,
+            }),
+            None => Err(ParseError::UnmatchedClose(')', current_span)),
+        }
+    }
+
+    fn parse_r_bracket(&mut self, current_span: Span) -> Result<(), ParseError> {
+        match self.stack.pop() {
+            Some(Frame::Vector(elems, span)) => {
+                self.push_to_frame(ExprKind::Vector(elems), span.full(current_span))
+            }
+            Some(Frame::List(_, span)) => Err(ParseError::MismatchedDelimiter {
+                expected: ')',
+                found: ']',
+                span,
+            }),
+            Some(Frame::Map(_, span)) => Err(ParseError::MismatchedDelimiter {
+                expected: '}',
+                found: ']',
+                span,
+            }),
+            None => Err(ParseError::UnmatchedClose(']', current_span)),
+        }
+    }
+
+    fn parse_r_brace(&mut self, current_span: Span) -> Result<(), ParseError> {
+        match self.stack.pop() {
+            Some(Frame::Map(elems, span)) => {
+                if elems.len() % 2 != 0 {
+                    return Err(ParseError::OddMapElements(current_span));
+                }
+                let map_elemen = elems
+                    .chunks(2)
+                    .map(|pair| (pair[0].clone(), pair[1].clone()))
+                    .collect::<Vec<(Expr, Expr)>>();
+
+                self.push_to_frame(ExprKind::Map(map_elemen), span.full(current_span))
+            }
+            Some(Frame::List(_, span)) => Err(ParseError::MismatchedDelimiter {
+                expected: ')',
+                found: '}',
+                span,
+            }),
+            Some(Frame::Vector(_, span)) => Err(ParseError::MismatchedDelimiter {
+                expected: ']',
+                found: '}',
+                span,
+            }),
+            None => Err(ParseError::UnmatchedClose('}', current_span)),
+        }
+    }
+}

--- a/risp/src/parser/test_parser.rs
+++ b/risp/src/parser/test_parser.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-use crate::{lexer::{Lexer, Token}, parser::Object};
+use crate::{lexer::Lexer, parser::Object};
 
 #[test]
 fn test_parser_add() {

--- a/risp/src/parser/test_parser.rs
+++ b/risp/src/parser/test_parser.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
-use crate::{lexer::Token, parser::Object};
+use crate::{lexer::{Lexer, Token}, parser::Object};
 
 #[test]
 fn test_parser_add() {
-    let tokens = Token::tokenize("(+ 1 2)");
+    let tokens = Lexer::tokenize("(+ 1 2)");
     let list = Object::from_tokens(tokens).unwrap();
     assert_eq!(
         list,
@@ -17,7 +17,7 @@ fn test_parser_add() {
 
 #[test]
 fn test_parse_list() {
-    let program = Token::tokenize("(1 2 3)");
+    let program = Lexer::tokenize("(1 2 3)");
     let list = Object::from_tokens(program).unwrap();
     assert_eq!(
         list,
@@ -36,7 +36,7 @@ fn test_area_of_a_circle() {
         (let pi 314)
         (* pi (* r r))
     )";
-    let tokens = Token::tokenize(program);
+    let tokens = Lexer::tokenize(program);
 
     let list = Object::from_tokens(tokens).unwrap();
     assert_eq!(
@@ -68,7 +68,7 @@ fn test_area_of_a_circle() {
 #[test]
 fn test_parse_unbalanced_expression_whitout_closing() {
     let program = "(+ 1 2";
-    let tokens = Token::tokenize(program);
+    let tokens = Lexer::tokenize(program);
 
     assert_eq!(tokens.len(), 4);
 
@@ -78,12 +78,12 @@ fn test_parse_unbalanced_expression_whitout_closing() {
 
     let err = objs_list.err().unwrap();
 
-    assert_eq!(format!("{}", err), "0:1 Unmatched opening parenthesis");
+    assert_eq!(format!("{}", err), "@0..1 Unmatched opening parenthesis");
 }
 #[test]
 fn test_unbalanced_single_r_paren() {
     let program = ")";
-    let tokens = Token::tokenize(program);
+    let tokens = Lexer::tokenize(program);
 
     assert_eq!(tokens.len(), 1);
 
@@ -93,12 +93,12 @@ fn test_unbalanced_single_r_paren() {
 
     let err = objs_list.err().unwrap();
 
-    assert_eq!(format!("{}", err), "0:1 Unmatched closing parenthesis");
+    assert_eq!(format!("{}", err), "@0..1 Unmatched closing parenthesis");
 }
 #[test]
 fn test_parse_unbalanced_expressions_with_extra_closing() {
     let program = "(+ 1 2))";
-    let tokens = Token::tokenize(program);
+    let tokens = Lexer::tokenize(program);
 
     assert_eq!(tokens.len(), 6);
 
@@ -108,7 +108,7 @@ fn test_parse_unbalanced_expressions_with_extra_closing() {
 
     let err = objs_list.err().unwrap();
 
-    assert_eq!(format!("{}", err), "0:8 Unmatched closing parenthesis");
+    assert_eq!(format!("{}", err), "@7..8 Unmatched closing parenthesis");
 }
 
 #[test]

--- a/risp/src/parser/test_parser_impl.rs
+++ b/risp/src/parser/test_parser_impl.rs
@@ -1,0 +1,201 @@
+#[cfg(test)]
+mod tests {
+    use crate::lexer::{Lexer, Span};
+    use crate::parser::cst::{Expr, ExprKind};
+    use crate::parser::parser_impl::ParseError;
+    use crate::parser::Parser;
+
+    fn span() -> Span {
+        Span { lo: 0, hi: 0 }
+    }
+
+    fn parse(input: &str) -> Vec<Expr> {
+        Parser::parse(Lexer::tokenize(input)).unwrap()
+    }
+
+    fn parse_err(input: &str) -> ParseError {
+        Parser::parse(Lexer::tokenize(input)).unwrap_err()
+    }
+
+    #[test]
+    fn parses_long() {
+        let result = parse("42");
+        assert_eq!(result[0].kind, ExprKind::Long(42));
+    }
+
+    #[test]
+    fn parses_negative_long() {
+        let result = parse("-7");
+        assert_eq!(result[0].kind, ExprKind::Long(-7));
+    }
+
+    #[test]
+    fn parses_double() {
+        let result = parse("3.14");
+        assert_eq!(result[0].kind, ExprKind::Double(3.14));
+    }
+
+    #[test]
+    fn parses_string() {
+        let result = parse("\"hello\"");
+        assert_eq!(result[0].kind, ExprKind::String("hello".to_string()));
+    }
+
+    #[test]
+    fn parses_keyword() {
+        let result = parse(":foo");
+        assert_eq!(result[0].kind, ExprKind::Keyword("foo".to_string()));
+    }
+
+    #[test]
+    fn parses_symbol() {
+        let result = parse("foo");
+        assert_eq!(result[0].kind, ExprKind::Symbol("foo".to_string()));
+    }
+
+    #[test]
+    fn parses_true() {
+        let result = parse("true");
+        assert_eq!(result[0].kind, ExprKind::Bool(true));
+    }
+
+    #[test]
+    fn parses_false() {
+        let result = parse("false");
+        assert_eq!(result[0].kind, ExprKind::Bool(false));
+    }
+
+    #[test]
+    fn parses_nil() {
+        let result = parse("nil");
+        assert_eq!(result[0].kind, ExprKind::Nil);
+    }
+
+    #[test]
+    fn parses_empty_list() {
+        let result = parse("()");
+        assert_eq!(result[0].kind, ExprKind::List(vec![]));
+    }
+
+    #[test]
+    fn parses_list() {
+        let result = parse("(+ 1 2)");
+        assert_eq!(
+            result[0].kind,
+            ExprKind::List(vec![
+                Expr::new(ExprKind::Symbol("+".to_string()), span()),
+                Expr::new(ExprKind::Long(1), span()),
+                Expr::new(ExprKind::Long(2), span()),
+            ])
+        );
+    }
+
+    #[test]
+    fn parses_empty_vector() {
+        let result = parse("[]");
+        assert_eq!(result[0].kind, ExprKind::Vector(vec![]));
+    }
+
+    #[test]
+    fn parses_vector() {
+        let result = parse("[1 2 3]");
+        assert_eq!(
+            result[0].kind,
+            ExprKind::Vector(vec![
+                Expr::new(ExprKind::Long(1), span()),
+                Expr::new(ExprKind::Long(2), span()),
+                Expr::new(ExprKind::Long(3), span()),
+            ])
+        );
+    }
+
+    #[test]
+    fn parses_empty_map() {
+        let result = parse("{}");
+        assert_eq!(result[0].kind, ExprKind::Map(vec![]));
+    }
+
+    #[test]
+    fn parses_map() {
+        let result = parse("{:a 1}");
+        assert_eq!(
+            result[0].kind,
+            ExprKind::Map(vec![(
+                Expr::new(ExprKind::Keyword("a".to_string()), span()),
+                Expr::new(ExprKind::Long(1), span()),
+            )])
+        );
+    }
+
+    #[test]
+    fn parses_nested() {
+        let result = parse("(+ [1 2] 3)");
+        assert_eq!(
+            result[0].kind,
+            ExprKind::List(vec![
+                Expr::new(ExprKind::Symbol("+".to_string()), span()),
+                Expr::new(
+                    ExprKind::Vector(vec![
+                        Expr::new(ExprKind::Long(1), span()),
+                        Expr::new(ExprKind::Long(2), span()),
+                    ]),
+                    span()
+                ),
+                Expr::new(ExprKind::Long(3), span()),
+            ])
+        );
+    }
+
+    #[test]
+    fn parses_multiple_forms() {
+        let result = parse("1 2 3");
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].kind, ExprKind::Long(1));
+        assert_eq!(result[1].kind, ExprKind::Long(2));
+        assert_eq!(result[2].kind, ExprKind::Long(3));
+    }
+
+    #[test]
+    fn error_unmatched_open_paren() {
+        let err = parse_err("(+ 1 2");
+        assert!(matches!(err, ParseError::UnmatchedOpen(_)));
+    }
+
+    #[test]
+    fn error_unmatched_close_paren() {
+        let err = parse_err(")");
+        assert!(matches!(err, ParseError::UnmatchedClose(')', _)));
+    }
+
+    #[test]
+    fn error_mismatched_paren_bracket() {
+        let err = parse_err("(+ 1 2]");
+        assert!(matches!(
+            err,
+            ParseError::MismatchedDelimiter {
+                expected: ')',
+                found: ']',
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn error_mismatched_bracket_paren() {
+        let err = parse_err("[1 2)");
+        assert!(matches!(
+            err,
+            ParseError::MismatchedDelimiter {
+                expected: ']',
+                found: ')',
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn error_odd_map_elements() {
+        let err = parse_err("{:a}");
+        assert!(matches!(err, ParseError::OddMapElements(_)));
+    }
+}


### PR DESCRIPTION
## Changes
  * **Features**
    * New `Parser` (`parser_impl.rs`) that produces a CST (`Expr`/`ExprKind`) from tokens
    * New `Expr` and `ExprKind` types (`cst.rs`) representing the concrete syntax tree — supports atoms (`Long`, `Double`, `Bool`, `Nil`, `String`, `Keyword`, `Symbol`), `List`, `Vector`
  and `Map`
    * `ParseError` enum with structured variants: `UnmatchedOpen`, `UnmatchedClose`, `MismatchedDelimiter` and `OddMapElements`
    * `Span::full()` helper to merge two spans into a single range
  * **Bugfixes**
    * N/A
  * **Misc**
    * Full test suite for the new parser (`test_parser_impl.rs`) covering all atom types, compound forms, nested structures, multiple top-level forms and all error variants
  * **Docs**
    * N/A

