### PR TITLE
Refactor/improving memory management

### DIFF
--- a/lib/src/interpreter/builtins/data_structures.rs
+++ b/lib/src/interpreter/builtins/data_structures.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use crate::interpreter::{RuntimeError, Value};
 use crate::lexer::Span;
 
@@ -6,17 +8,17 @@ fn list(args: &[(Value, Span)], _: Span) -> Result<Value, RuntimeError> {
 }
 
 fn vec(args: &[(Value, Span)], _: Span) -> Result<Value, RuntimeError> {
-    Ok(Value::Vector(
+    Ok(Value::Vector(Rc::new(
         args.iter().map(|t| t.0.clone()).collect::<Vec<Value>>(),
-    ))
+    )))
 }
 
 fn map(args: &[(Value, Span)], _: Span) -> Result<Value, RuntimeError> {
-    Ok(Value::Map(
+    Ok(Value::Map(Rc::new(
         args.chunks(2)
             .map(|pair| (pair[0].0.clone(), pair[1].0.clone()))
             .collect::<Vec<(Value, Value)>>(),
-    ))
+    )))
 }
 
 pub fn builtins() -> Vec<(&'static str, Value)> {

--- a/lib/src/interpreter/builtins/sequences.rs
+++ b/lib/src/interpreter/builtins/sequences.rs
@@ -319,7 +319,7 @@ fn cons(elems: &[(Value, Span)], span: Span) -> Result<Value, RuntimeError> {
     let (col, col_span) = &elems[1];
 
     match (value, col) {
-        (_, Value::List(c)) => Ok(Value::List(RispList::cons(value.clone(), &c))),
+        (_, Value::List(c)) => Ok(Value::List(RispList::cons(value.clone(), c))),
         (_, Value::Vector(c)) | (_, Value::Set(c)) => Ok(Value::List(
             std::iter::once(value.clone()).chain(c.clone()).collect(),
         )),

--- a/lib/src/interpreter/builtins/sequences.rs
+++ b/lib/src/interpreter/builtins/sequences.rs
@@ -1,10 +1,12 @@
+use std::rc::Rc;
+
 use crate::collections::RispList;
 use crate::interpreter::{RuntimeError, Value};
 use crate::lexer::Span;
 
 fn seq_to_list(v: Value) -> Value {
     match v {
-        Value::Vector(vec) => Value::List(vec.into_iter().collect()),
+        Value::Vector(vec) => Value::List(vec.iter().cloned().collect()),
         other => other,
     }
 }
@@ -44,7 +46,7 @@ fn first(elems: &[(Value, Span)], span: Span) -> Result<Value, RuntimeError> {
                 None => Ok(Value::Nil),
             },
             (Value::Map(m), _) => match m.first() {
-                Some(f) => Ok(Value::Vector(vec![f.0.clone(), f.1.clone()])),
+                Some(f) => Ok(Value::Vector(Rc::new(vec![f.0.clone(), f.1.clone()]))),
                 None => Ok(Value::Nil),
             },
             (value, span) => Err(RuntimeError::TypeError {
@@ -91,7 +93,7 @@ fn rest(elems: &[(Value, Span)], span: Span) -> Result<Value, RuntimeError> {
             if !m.is_empty() {
                 let result = m[1..]
                     .iter()
-                    .map(|(k, v)| Value::Vector(vec![k.clone(), v.clone()]))
+                    .map(|(k, v)| Value::Vector(Rc::new(vec![k.clone(), v.clone()])))
                     .collect::<RispList<Value>>();
                 Ok(Value::List(result))
             } else {
@@ -134,7 +136,7 @@ fn second(elems: &[(Value, Span)], span: Span) -> Result<Value, RuntimeError> {
                 Ok(Value::Nil)
             } else {
                 let (k, v) = m[2].clone();
-                Ok(Value::Vector(vec![k, v]))
+                Ok(Value::Vector(Rc::new(vec![k, v])))
             }
         }
         (v, s) => Err(RuntimeError::TypeError {
@@ -157,7 +159,7 @@ fn last(elems: &[(Value, Span)], span: Span) -> Result<Value, RuntimeError> {
                 None => Ok(Value::Nil),
             },
             (Value::Map(m), _) => match m.last() {
-                Some(f) => Ok(Value::Vector(vec![f.0.clone(), f.1.clone()])),
+                Some(f) => Ok(Value::Vector(Rc::new(vec![f.0.clone(), f.1.clone()]))),
                 None => Ok(Value::Nil),
             },
             (value, span) => Err(RuntimeError::TypeError {
@@ -235,32 +237,35 @@ fn conj(elems: &[(Value, Span)], span: Span) -> Result<Value, RuntimeError> {
 
     match col {
         Value::Vector(v) => {
-            let mut result = v.clone();
-            result.push(val.clone());
-            Ok(Value::Vector(result))
+            let result: Vec<Value> = v
+                .iter()
+                .cloned()
+                .chain(std::iter::once(val.clone()))
+                .collect();
+            Ok(Value::Vector(Rc::new(result)))
         }
         Value::List(l) => Ok(Value::List(RispList::cons(val.clone(), l))),
         Value::Set(s) => {
             let val = seq_to_list(val.clone());
-            let mut result = s.clone();
+            let mut result: Vec<Value> = s.iter().cloned().collect();
             if !result.contains(&val) {
                 result.push(val);
             }
-            Ok(Value::Set(result))
+            Ok(Value::Set(Rc::new(result)))
         }
         Value::Map(m) => {
             let pair = match val {
                 Value::Vector(v) if v.len() == 2 => Ok((v[0].clone(), v[1].clone())),
                 Value::Map(other) => {
-                    let mut result = m.clone();
-                    for (k, v) in other {
+                    let mut result: Vec<(Value, Value)> = m.iter().cloned().collect();
+                    for (k, v) in other.iter() {
                         if let Some(entry) = result.iter_mut().find(|(ek, _)| ek == k) {
                             entry.1 = v.clone();
                         } else {
                             result.push((k.clone(), v.clone()));
                         }
                     }
-                    return Ok(Value::Map(result));
+                    return Ok(Value::Map(Rc::new(result)));
                 }
                 v => Err(RuntimeError::TypeError {
                     expected: "vector pair or map",
@@ -269,13 +274,13 @@ fn conj(elems: &[(Value, Span)], span: Span) -> Result<Value, RuntimeError> {
                 }),
             }?;
 
-            let mut result = m.clone();
+            let mut result: Vec<(Value, Value)> = m.iter().cloned().collect();
             if let Some(entry) = result.iter_mut().find(|(k, _)| k == &pair.0) {
                 entry.1 = pair.1;
             } else {
                 result.push(pair);
             }
-            Ok(Value::Map(result))
+            Ok(Value::Map(Rc::new(result)))
         }
         v => Err(RuntimeError::TypeError {
             expected: "seq",
@@ -321,12 +326,14 @@ fn cons(elems: &[(Value, Span)], span: Span) -> Result<Value, RuntimeError> {
     match (value, col) {
         (_, Value::List(c)) => Ok(Value::List(RispList::cons(value.clone(), c))),
         (_, Value::Vector(c)) | (_, Value::Set(c)) => Ok(Value::List(
-            std::iter::once(value.clone()).chain(c.clone()).collect(),
+            std::iter::once(value.clone())
+                .chain(c.iter().cloned())
+                .collect(),
         )),
         (_, Value::Map(m)) => {
             let map_col = m
                 .iter()
-                .map(|(k, v)| Value::Vector(vec![k.clone(), v.clone()]))
+                .map(|(k, v)| Value::Vector(Rc::new(vec![k.clone(), v.clone()])))
                 .collect::<Vec<Value>>();
             Ok(Value::List(
                 std::iter::once(value.clone()).chain(map_col).collect(),

--- a/lib/src/interpreter/builtins/stdio.rs
+++ b/lib/src/interpreter/builtins/stdio.rs
@@ -22,9 +22,8 @@ fn write(args: &[(Value, Span)], span: Span) -> Result<Value, RuntimeError> {
 }
 
 fn str_conv(args: &[(Value, Span)], _: Span) -> Result<Value, RuntimeError> {
-    Ok(Value::String(
-        args.iter().map(|(v, _)| v.to_string()).collect(),
-    ))
+    let result: String = args.iter().map(|(v, _)| v.to_string()).collect();
+    Ok(Value::String(result.into()))
 }
 
 pub fn builtins() -> Vec<(&'static str, Value)> {

--- a/lib/src/interpreter/builtins/test_data_structures.rs
+++ b/lib/src/interpreter/builtins/test_data_structures.rs
@@ -36,7 +36,7 @@ mod tests {
     fn vector_builtin_elements() {
         assert!(matches!(
             run("(vector 1 2 3)"),
-            Value::Vector(v) if v == vec![Value::Long(1), Value::Long(2), Value::Long(3)]
+            Value::Vector(v) if *v == vec![Value::Long(1), Value::Long(2), Value::Long(3)]
         ));
     }
 

--- a/lib/src/interpreter/builtins/test_data_structures.rs
+++ b/lib/src/interpreter/builtins/test_data_structures.rs
@@ -56,7 +56,7 @@ mod tests {
         match result {
             Value::Map(m) => {
                 assert_eq!(m.len(), 1);
-                assert_eq!(m[0].0, Value::Keyword("a".to_string()));
+                assert_eq!(m[0].0, Value::Keyword("a".into()));
                 assert_eq!(m[0].1, Value::Long(1));
             }
             _ => panic!("expected Map"),

--- a/lib/src/interpreter/builtins/test_hof.rs
+++ b/lib/src/interpreter/builtins/test_hof.rs
@@ -25,7 +25,7 @@ mod tests {
 
     #[test]
     fn map_applies_function() {
-        assert!(matches!(run("(map (fn [x] (* x 2)) [1 2 3])"), Value::Vector(v) if v == vec![Value::Long(2), Value::Long(4), Value::Long(6)]));
+        assert!(matches!(run("(map (fn [x] (* x 2)) [1 2 3])"), Value::Vector(v) if *v == vec![Value::Long(2), Value::Long(4), Value::Long(6)]));
     }
 
     #[test]

--- a/lib/src/interpreter/env/mod.rs
+++ b/lib/src/interpreter/env/mod.rs
@@ -64,11 +64,11 @@ impl Env {
         self.registry.borrow_mut().create(ns_name, referred);
     }
 
-    pub fn get_current_namespace(&self) -> String {
+    pub fn get_current_namespace(&self) -> Rc<str> {
         self.registry.borrow().current.clone()
     }
 
     pub fn set_current_namespace(&self, ns: &str) {
-        self.registry.borrow_mut().current = ns.to_string();
+        self.registry.borrow_mut().current = ns.into();
     }
 }

--- a/lib/src/interpreter/env/namespace.rs
+++ b/lib/src/interpreter/env/namespace.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use crate::interpreter::Value;
 
@@ -38,7 +39,7 @@ impl Default for Namespace {
 
 pub struct NamespaceRegistry {
     namespaces: HashMap<String, Namespace>,
-    pub current: String,
+    pub current: Rc<str>,
 }
 
 impl NamespaceRegistry {
@@ -56,7 +57,7 @@ impl NamespaceRegistry {
     }
 
     pub fn public_names(&self) -> Vec<String> {
-        let Some(current) = self.namespaces.get(&self.current) else {
+        let Some(current) = self.namespaces.get(self.current.as_ref()) else {
             return vec![];
         };
         let mut names: Vec<String> = current.global_names().map(|s| s.to_string()).collect();
@@ -70,7 +71,7 @@ impl NamespaceRegistry {
 
     pub fn set(&mut self, name: &str, value: Value) {
         self.namespaces
-            .entry(self.current.clone())
+            .entry(self.current.to_string())
             .or_insert_with(|| Namespace::new(&self.current))
             .defs
             .insert(name.to_string(), value);
@@ -101,7 +102,7 @@ impl Default for NamespaceRegistry {
     fn default() -> Self {
         Self {
             namespaces: Default::default(),
-            current: "user".to_string(),
+            current: "user".into(),
         }
     }
 }

--- a/lib/src/interpreter/implementation/eval_call.rs
+++ b/lib/src/interpreter/implementation/eval_call.rs
@@ -94,9 +94,9 @@ impl Interpreter {
                         let arg = self.eval(&args[0])?;
                         match arg {
                             Value::Map(pairs) => Ok(pairs
-                                .into_iter()
+                                .iter()
                                 .find(|(key, _)| matches!(key, Value::Keyword(s) if *s == v))
-                                .map(|(_, v)| v)
+                                .map(|(_, v)| v.clone())
                                 .unwrap_or(Value::Nil)),
                             _ => Err(RuntimeError::TypeError {
                                 expected: "map",

--- a/lib/src/interpreter/implementation/eval_hof.rs
+++ b/lib/src/interpreter/implementation/eval_hof.rs
@@ -5,7 +5,7 @@ use crate::sema::AstNode;
 fn to_vec(val: Value, span: Span) -> Result<Vec<Value>, RuntimeError> {
     match val {
         Value::List(l) => Ok(l.iter().cloned().collect()),
-        Value::Vector(v) => Ok(v),
+        Value::Vector(v) => Ok((*v).clone()),
         v => Err(RuntimeError::TypeError {
             expected: "list or vector",
             got: v.type_name(),

--- a/lib/src/interpreter/implementation/eval_literals.rs
+++ b/lib/src/interpreter/implementation/eval_literals.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use super::{Interpreter, RuntimeError, Value};
 use crate::collections::RispList;
 use crate::lexer::Span;
@@ -5,7 +7,7 @@ use crate::sema::AstNode;
 
 fn seq_to_list(v: Value) -> Value {
     match v {
-        Value::Vector(vec) => Value::List(vec.into_iter().collect()),
+        Value::Vector(vec) => Value::List(vec.iter().cloned().collect()),
         other => other,
     }
 }
@@ -65,7 +67,7 @@ impl Interpreter {
             .iter()
             .map(|e| self.eval(e))
             .collect::<Result<Vec<_>, _>>()
-            .map(Value::Vector)
+            .map(|v| Value::Vector(Rc::new(v)))
     }
 
     pub(super) fn eval_map_literal(
@@ -76,7 +78,7 @@ impl Interpreter {
             .iter()
             .map(|(k, v)| Ok((self.eval(k)?, self.eval(v)?)))
             .collect::<Result<Vec<_>, _>>()
-            .map(Value::Map)
+            .map(|v| Value::Map(Rc::new(v)))
     }
 
     pub(super) fn eval_set_literal(&mut self, elems: &[AstNode]) -> Result<Value, RuntimeError> {
@@ -87,6 +89,6 @@ impl Interpreter {
                 values.push(v);
             }
         }
-        Ok(Value::Set(values))
+        Ok(Value::Set(Rc::new(values)))
     }
 }

--- a/lib/src/interpreter/implementation/mod.rs
+++ b/lib/src/interpreter/implementation/mod.rs
@@ -19,6 +19,12 @@ pub struct Interpreter {
     pub(super) env: Rc<RefCell<Env>>,
 }
 
+impl Default for Interpreter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Interpreter {
     pub fn new() -> Self {
         let env = Rc::new(RefCell::new(Env::default()));
@@ -70,8 +76,8 @@ impl Interpreter {
             Node::Double(n) => Ok(Value::Double(*n)),
             Node::Bool(b) => Ok(Value::Bool(*b)),
             Node::Nil => Ok(Value::Nil),
-            Node::String(s) => Ok(Value::String(s.clone())),
-            Node::Keyword(s) => Ok(Value::Keyword(s.clone())),
+            Node::String(s) => Ok(Value::String(Rc::from(s.as_str()))),
+            Node::Keyword(s) => Ok(Value::Keyword(Rc::from(s.as_str()))),
             Node::Var(id) => self.eval_var(*id, node.span),
             Node::GlobalVar(name) => self.eval_global_var(name, node.span),
             Node::QualifiedVar { ns, name } => self.eval_qualified_var(ns, name, node.span),
@@ -86,7 +92,7 @@ impl Interpreter {
             Node::Vector(elems) => self.eval_vector_literal(elems),
             Node::Map(pairs) => self.eval_map_literal(pairs),
             Node::Set(elems) => self.eval_set_literal(elems),
-            Node::Symbol(s) => Ok(Value::Symbol(s.clone())),
+            Node::Symbol(s) => Ok(Value::Symbol(Rc::from(s.as_str()))),
             Node::Loop { bindings, body } => self.eval_loop(bindings, body),
             Node::Recur(_) => Err(RuntimeError::RecurOutsideLoop { span: node.span }),
         }

--- a/lib/src/interpreter/test_interpreter.rs
+++ b/lib/src/interpreter/test_interpreter.rs
@@ -47,12 +47,12 @@ mod tests {
 
     #[test]
     fn eval_string() {
-        assert!(matches!(run("\"hello\""), Value::String(s) if s == "hello"));
+        assert!(matches!(run("\"hello\""), Value::String(s) if s.as_ref() == "hello"));
     }
 
     #[test]
     fn eval_keyword() {
-        assert!(matches!(run(":foo"), Value::Keyword(s) if s == "foo"));
+        assert!(matches!(run(":foo"), Value::Keyword(s) if s.as_ref() == "foo"));
     }
 
     #[test]
@@ -216,7 +216,7 @@ mod tests {
 
     #[test]
     fn eval_quoted_symbol() {
-        assert!(matches!(run("'foo"), Value::Symbol(s) if s == "foo"));
+        assert!(matches!(run("'foo"), Value::Symbol(s) if s.as_ref() == "foo"));
     }
 
     #[test]
@@ -420,7 +420,7 @@ mod tests {
     fn eval_and_in_if_condition() {
         assert!(matches!(
             run_with_builtins("(if (and (> 5 3) (< 1 2)) :yes :no)"),
-            Value::Keyword(s) if s == "yes"
+            Value::Keyword(s) if s.as_ref() == "yes"
         ));
     }
 
@@ -428,7 +428,7 @@ mod tests {
     fn eval_or_in_if_condition() {
         assert!(matches!(
             run_with_builtins("(if (or false (= 1 1)) :yes :no)"),
-            Value::Keyword(s) if s == "yes"
+            Value::Keyword(s) if s.as_ref() == "yes"
         ));
     }
 
@@ -470,7 +470,7 @@ mod tests {
     fn eval_defn_sets_closure_name() {
         assert!(matches!(
             run_with_builtins("(defn foo [x] x) (str foo)"),
-            Value::String(s) if s == "#<fn foo>"
+            Value::String(s) if s.as_ref() == "#<fn foo>"
         ));
     }
 
@@ -478,27 +478,27 @@ mod tests {
     fn eval_fn_anonymous_has_no_name() {
         assert!(matches!(
             run_with_builtins("(str (fn [x] x))"),
-            Value::String(s) if s == "#<fn lamba>"
+            Value::String(s) if s.as_ref() == "#<fn lamba>"
         ));
     }
 
     #[test]
     fn eval_string_escape_newline() {
-        assert!(matches!(run("\"a\\nb\""), Value::String(s) if s == "a\nb"));
+        assert!(matches!(run("\"a\\nb\""), Value::String(s) if s.as_ref() == "a\nb"));
     }
 
     #[test]
     fn eval_string_escape_tab() {
-        assert!(matches!(run("\"a\\tb\""), Value::String(s) if s == "a\tb"));
+        assert!(matches!(run("\"a\\tb\""), Value::String(s) if s.as_ref() == "a\tb"));
     }
 
     #[test]
     fn eval_string_escape_double_quote() {
-        assert!(matches!(run("\"a\\\"b\""), Value::String(s) if s == "a\"b"));
+        assert!(matches!(run("\"a\\\"b\""), Value::String(s) if s.as_ref() == "a\"b"));
     }
 
     #[test]
     fn eval_string_escape_backslash() {
-        assert!(matches!(run("\"a\\\\b\""), Value::String(s) if s == "a\\b"));
+        assert!(matches!(run("\"a\\\\b\""), Value::String(s) if s.as_ref() == "a\\b"));
     }
 }

--- a/lib/src/interpreter/value.rs
+++ b/lib/src/interpreter/value.rs
@@ -104,9 +104,9 @@ pub enum Value {
     String(Rc<str>),
     Keyword(Rc<str>),
     List(RispList<Value>),
-    Vector(Vec<Value>),
-    Map(Vec<(Value, Value)>),
-    Set(Vec<Value>),
+    Vector(Rc<Vec<Value>>),
+    Map(Rc<Vec<(Value, Value)>>),
+    Set(Rc<Vec<Value>>),
     Symbol(Rc<str>),
     Callable(Rc<Callable>),
 }

--- a/lib/src/interpreter/value.rs
+++ b/lib/src/interpreter/value.rs
@@ -101,13 +101,13 @@ pub enum Value {
     Bool(bool),
     Long(i64),
     Double(f64),
-    String(String),
-    Keyword(String),
+    String(Rc<str>),
+    Keyword(Rc<str>),
     List(RispList<Value>),
     Vector(Vec<Value>),
     Map(Vec<(Value, Value)>),
     Set(Vec<Value>),
-    Symbol(String),
+    Symbol(Rc<str>),
     Callable(Rc<Callable>),
 }
 


### PR DESCRIPTION
## Changes

  - **Features**
    - `Rc<str>` for `Value::String`,  `Value::Keyword`, `Value::Symbol`, `O(1)` clone instead of `O(n)`
    - `Rc<Vec>` for `Value::Vector`, `Value::Map`, `Value::Set`, `O(1)` clone for collection values
    - Interpreter now implements Default
  - **Bugfixes**
    - `Value::Callable` display double-wrapping fixed `(#<fn #<fn foo> > → #<fn foo>)`
    - `conj` on `Vector` rebuilt with single-pass `iter().cloned().chain()`, no intermediate `Vec` clone
    - `NamespaceRegistry.current` migrated to `Rc<str>`
  - **Misc**
    - Tests updated for `Rc<str>` comparisons `(s.as_ref() == "...")`
